### PR TITLE
Lowercase the project name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 enabled = true
 
 [project]
-name = "EasyScience"
+name = "easyscience"
 dynamic = ["version"]
 description = "Generic logic for easyScience libraries"
 readme = "README.md"
@@ -81,7 +81,7 @@ packages = ["src/easyscience"]
 source = ["src/easyscience"]
 
 [tool.github.info]
-organization = 'easyScience'
+organization = 'EasyScience'
 repo = "easyscience"
 
 [tool.ruff]


### PR DESCRIPTION
This PR should change how the easyscience package name is displayed on [pypi](https://pypi.org/project/EasyScience) from `EasyScience` to `easyscience`.