### PR TITLE
58 ensure values are always floats

### DIFF
--- a/src/easyscience/Objects/new_variable/descriptor_number.py
+++ b/src/easyscience/Objects/new_variable/descriptor_number.py
@@ -101,7 +101,7 @@ class DescriptorNumber(DescriptorBase):
 
     @full_value.setter
     def full_value(self, full_value: Variable) -> None:
-        raise AttributeError(f'Full_value is read-only. Change the value and variance seperately. or create a new {self.__class__.__name__}.')  # noqa: E501
+        raise AttributeError(f'Full_value is read-only. Change the value and variance seperately. Or create a new {self.__class__.__name__}.')  # noqa: E501
     
     @property
     def value(self) -> numbers.Number:

--- a/src/easyscience/Objects/new_variable/descriptor_number.py
+++ b/src/easyscience/Objects/new_variable/descriptor_number.py
@@ -122,7 +122,7 @@ class DescriptorNumber(DescriptorBase):
         """
         if not isinstance(value, numbers.Number) or isinstance(value, bool):
             raise TypeError(f'{value=} must be a number')
-        self._scalar.value = value
+        self._scalar.value = float(value)
 
     @property
     def unit(self) -> str:

--- a/src/easyscience/Objects/new_variable/parameter.py
+++ b/src/easyscience/Objects/new_variable/parameter.py
@@ -148,7 +148,7 @@ class Parameter(DescriptorNumber):
 
     @full_value.setter
     def full_value(self, scalar: Variable) -> None:
-        raise AttributeError(f'Full_value is read-only. Change the value and variance seperately. or create a new {self.__class__.__name__}.')  # noqa: E501
+        raise AttributeError(f'Full_value is read-only. Change the value and variance seperately. Or create a new {self.__class__.__name__}.')  # noqa: E501
 
     @property
     def value(self) -> numbers.Number:

--- a/src/easyscience/Objects/new_variable/parameter.py
+++ b/src/easyscience/Objects/new_variable/parameter.py
@@ -147,24 +147,8 @@ class Parameter(DescriptorNumber):
         return self._scalar
 
     @full_value.setter
-    @property_stack_deco
     def full_value(self, scalar: Variable) -> None:
-        """
-        Set the value of self. This creates a scipp scalar with a unit.
-
-        :param full_value: New value of self
-        """
-        if not self.enabled:
-            if global_object.debug:
-                raise CoreSetException(f'{str(self)} is not enabled.')
-            return
-        if not isinstance(scalar, Variable) and len(scalar.dims) == 0:
-            raise TypeError(f'{scalar=} must be a Scipp scalar')
-        if not isinstance(scalar.value, numbers.Number) or isinstance(scalar.value, bool):
-            raise TypeError('value of Scipp scalar must be a number')
-        self._scalar = scalar
-        if self._callback.fset is not None:
-            self._callback.fset(scalar)
+        raise AttributeError(f'Full_value is read-only. Change the value and variance seperately. or create a new {self.__class__.__name__}.')  # noqa: E501
 
     @property
     def value(self) -> numbers.Number:

--- a/src/easyscience/Objects/new_variable/parameter.py
+++ b/src/easyscience/Objects/new_variable/parameter.py
@@ -199,7 +199,7 @@ class Parameter(DescriptorNumber):
 
         value = self._constraint_runner(self._constraints.virtual, value)
 
-        self._scalar.value = value
+        self._scalar.value = float(value)
         if self._callback.fset is not None:
             self._callback.fset(self._scalar.value)
 

--- a/tests/unit_tests/Objects/new_variable/test_parameter.py
+++ b/tests/unit_tests/Objects/new_variable/test_parameter.py
@@ -292,15 +292,9 @@ class TestParameter:
         assert parameter._callback.fget.call_count == 1
 
     def test_set_full_value(self, parameter: Parameter):
-        # When
-        self.mock_callback.fget.return_value = sc.scalar(1, unit='m')
-
-        # Then
-        parameter.full_value = sc.scalar(2, unit='m')
-
-        # Expect
-        parameter._callback.fset.assert_called_once_with(sc.scalar(2, unit='m')) 
-        assert parameter._scalar == sc.scalar(2, unit='m')
+        # When Then Expect
+        with pytest.raises(AttributeError):
+            parameter.full_value = sc.scalar(2, unit='s')
     
     def test_copy(self, parameter: Parameter):
         # When Then


### PR DESCRIPTION
Small fixes:
Ensure that all value setters always take float of input to avoid Integer Scipp scalars.
Remove full_value setter of `Parameter`

Original PR was #62, but it was mistakenly merged into Master branch