### PR TITLE
Added Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha"
 ]
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 dependencies = [
     "asteval",
     "bumps",


### PR DESCRIPTION
To facilitate deployment on new VISA instances, we need to support Python 3.12.
It seems this has no negative effects.
