### PR TITLE
unique name when created from dict

### DIFF
--- a/src/easyscience/Utils/io/template.py
+++ b/src/easyscience/Utils/io/template.py
@@ -257,11 +257,7 @@ class BaseEncoderDecoder:
                 mod = __import__(modname, globals(), locals(), [classname], 0)
                 if hasattr(mod, classname):
                     cls_ = getattr(mod, classname)
-                    data = {
-                        k: BaseEncoderDecoder._convert_from_dict(v)
-                        for k, v in d.items()
-                        if not (k.startswith('@') or k == 'unique_name')
-                    }
+                    data = {k: BaseEncoderDecoder._convert_from_dict(v) for k, v in d.items() if not k.startswith('@')}
                     return cls_(**data)
             elif np is not None and modname == 'numpy' and classname == 'array':
                 if d['dtype'].startswith('complex'):

--- a/tests/unit_tests/Objects/test_BaseObj.py
+++ b/tests/unit_tests/Objects/test_BaseObj.py
@@ -236,6 +236,23 @@ def test_baseobj_as_dict(setup_pars: dict):
     check_dict(expected, obtained)
 
 
+def test_baseobj_dict_roundtrip(clear, setup_pars: dict):
+    # When
+    name = setup_pars["name"]
+    del setup_pars["name"]
+    obj = BaseObj(name, **setup_pars, unique_name='special_name')
+    obj_dict = obj.as_dict()
+
+    global_object.map._clear()
+
+    # Then
+    new_obj = BaseObj.from_dict(obj_dict)
+
+    # Expect
+    new_obj_dict = new_obj.as_dict()
+    assert obj_dict == new_obj_dict
+
+
 def test_baseobj_dir(setup_pars):
     name = setup_pars["name"]
     del setup_pars["name"]

--- a/tests/unit_tests/utils/io_tests/test_core.py
+++ b/tests/unit_tests/utils/io_tests/test_core.py
@@ -131,8 +131,8 @@ class A(BaseObj):
 
 
 class B(BaseObj):
-    def __init__(self, a, b):
-        super(B, self).__init__("B", a=a)
+    def __init__(self, a, b, unique_name):
+        super(B, self).__init__("B", a=a, unique_name=unique_name)
         self.b = b
 
 

--- a/tests/unit_tests/utils/io_tests/test_dict.py
+++ b/tests/unit_tests/utils/io_tests/test_dict.py
@@ -207,8 +207,8 @@ def test_custom_class_encode_data(dp_kwargs: dict, dp_cls: Type[DescriptorNumber
 
 def test_custom_class_full_encode_with_numpy():
     class B(BaseObj):
-        def __init__(self, a, b):
-            super(B, self).__init__("B", a=a)
+        def __init__(self, a, b, unique_name):
+            super(B, self).__init__("B", a=a, unique_name=unique_name)
             self.b = b
     # Same as in __init__.py for easyscience
     try:
@@ -216,7 +216,7 @@ def test_custom_class_full_encode_with_numpy():
     except metadata.PackageNotFoundError:
         version = '0.0.0'
 
-    obj = B(DescriptorNumber("a", 1.0, unique_name="a"), np.array([1.0, 2.0, 3.0]))
+    obj = B(DescriptorNumber("a", 1.0, unique_name="a"), np.array([1.0, 2.0, 3.0]), unique_name="B_0")
     full_enc = obj.encode(encoder=DictSerializer, full_encode=True)
     expected = {
         "@module": "tests.unit_tests.utils.io_tests.test_dict",
@@ -248,7 +248,7 @@ def test_custom_class_full_encode_with_numpy():
 
 def test_custom_class_full_decode_with_numpy():
     global_object.map._clear()
-    obj = B(DescriptorNumber("a", 1.0), np.array([1.0, 2.0, 3.0]))
+    obj = B(DescriptorNumber("a", 1.0), np.array([1.0, 2.0, 3.0]), unique_name="B_0")
     full_enc = obj.encode(encoder=DictSerializer, full_encode=True)
     global_object.map._clear()
     obj2 = B.decode(full_enc, decoder=DictSerializer)


### PR DESCRIPTION
We need to keep the `unique_name` in order to be able to reproduce the object.

We are still able to get a copy by using a dict where we skip the `unique_name` 