### PR TITLE
Add the property `free` to the class `Parameter` as an alias for `not fixed`

### DIFF
--- a/src/easyscience/Objects/Variable.py
+++ b/src/easyscience/Objects/Variable.py
@@ -503,7 +503,6 @@ class Parameter(Descriptor):
         min: Optional[numbers.Number] = -np.inf,
         max: Optional[numbers.Number] = np.inf,
         fixed: Optional[bool] = False,
-        free: Optional[bool] = True,
         **kwargs,
     ):
         """

--- a/src/easyscience/Objects/Variable.py
+++ b/src/easyscience/Objects/Variable.py
@@ -503,6 +503,7 @@ class Parameter(Descriptor):
         min: Optional[numbers.Number] = -np.inf,
         max: Optional[numbers.Number] = np.inf,
         fixed: Optional[bool] = False,
+        free: Optional[bool] = True,
         **kwargs,
     ):
         """
@@ -720,6 +721,14 @@ class Parameter(Descriptor):
         if not isinstance(value, bool):
             raise ValueError
         self._fixed = value
+
+    @property
+    def free(self) -> bool:
+        return not self.fixed
+
+    @free.setter
+    def free(self, value: bool) -> None:
+        self.fixed = not value
 
     @property
     def error(self) -> float:

--- a/src/easyscience/Objects/new_variable/parameter.py
+++ b/src/easyscience/Objects/new_variable/parameter.py
@@ -49,7 +49,6 @@ class Parameter(DescriptorNumber):
         min: Optional[numbers.Number] = -np.inf,
         max: Optional[numbers.Number] = np.inf,
         fixed: Optional[bool] = False,
-        free: Optional[bool] = True,
         unique_name: Optional[str] = None,
         description: Optional[str] = None,
         url: Optional[str] = None,

--- a/src/easyscience/Objects/new_variable/parameter.py
+++ b/src/easyscience/Objects/new_variable/parameter.py
@@ -49,6 +49,7 @@ class Parameter(DescriptorNumber):
         min: Optional[numbers.Number] = -np.inf,
         max: Optional[numbers.Number] = np.inf,
         fixed: Optional[bool] = False,
+        free: Optional[bool] = True,
         unique_name: Optional[str] = None,
         description: Optional[str] = None,
         url: Optional[str] = None,
@@ -300,6 +301,14 @@ class Parameter(DescriptorNumber):
         if not isinstance(fixed, bool):
             raise ValueError(f'{fixed=} must be a boolean. Got {type(fixed)}')
         self._fixed = fixed
+
+    @property
+    def free(self) -> bool:
+        return not self.fixed
+
+    @free.setter
+    def free(self, value: bool) -> None:
+        self.fixed = not value
 
     @property
     def bounds(self) -> Tuple[numbers.Number, numbers.Number]:

--- a/tests/unit_tests/Objects/new_variable/test_parameter.py
+++ b/tests/unit_tests/Objects/new_variable/test_parameter.py
@@ -328,7 +328,6 @@ class TestParameter:
             "min": 0,
             "max": 10,
             "fixed": False,
-            "free": True,
             "description": "description",
             "url": "url",
             "display_name": "display_name",

--- a/tests/unit_tests/Objects/new_variable/test_parameter.py
+++ b/tests/unit_tests/Objects/new_variable/test_parameter.py
@@ -328,6 +328,7 @@ class TestParameter:
             "min": 0,
             "max": 10,
             "fixed": False,
+            "free": True,
             "description": "description",
             "url": "url",
             "display_name": "display_name",


### PR DESCRIPTION
This is the first step in implementing the property `free` for the class `Parameter`, in line with our discussion  https://github.com/EasyScience/EasyScience/discussions/20 as well as the issue https://github.com/EasyScience/EasyScience/issues/24. 

For now, the property `free` has been added as an alias to `not fixed`. 