### PR TITLE
Allow parameter value to be changed even if parameter is not enabled

### DIFF
--- a/src/easyscience/Objects/Variable.py
+++ b/src/easyscience/Objects/Variable.py
@@ -304,10 +304,6 @@ class Descriptor(ComponentSerializer):
         :param value: New value of self
         :return: None
         """
-        if not self.enabled:
-            if global_object.debug:
-                raise CoreSetException(f'{str(self)} is not enabled.')
-            return
         self.__deepValueSetter(value)
         if self._callback.fset is not None:
             try:

--- a/tests/unit_tests/Objects/test_Descriptor_Parameter.py
+++ b/tests/unit_tests/Objects/test_Descriptor_Parameter.py
@@ -134,32 +134,19 @@ def test_Parameter_value_get(element, expected):
 def test_item_value_set(instance, enabled, debug):
     global_object.debug = debug
     set_value = 2
+
     d = instance("test", 1)
     if enabled is not None:
         d.enabled = enabled
-    else:
-        enabled = True
-    if enabled:
-        d.value = set_value
-        assert d.raw_value == set_value
-    else:
-        if debug:
-            with pytest.raises(CoreSetException):
-                d.value = set_value
+    d.value = set_value
+    assert d.raw_value == set_value
+
     d = instance("test", 1, units="kelvin")
     if enabled is not None:
         d.enabled = enabled
-    else:
-        enabled = True
-
-    if enabled:
-        d.value = set_value
-        assert d.raw_value == set_value
-        assert str(d.unit) == "kelvin"
-    else:
-        if debug:
-            with pytest.raises(CoreSetException):
-                d.value = set_value
+    d.value = set_value
+    assert d.raw_value == set_value
+    assert str(d.unit) == "kelvin"
 
 
 @pytest.mark.parametrize("instance", (Descriptor, Parameter), indirect=True)


### PR DESCRIPTION
We need to be able to set a new value for a parameter, even if that parameter is not currently enabled.