### PR TITLE
Updating bindings throws errors on value query on Descriptors

### DIFF
--- a/src/easyscience/Objects/Inferface.py
+++ b/src/easyscience/Objects/Inferface.py
@@ -164,7 +164,12 @@ class InterfaceFactoryTemplate:
                 prop = props[idx]
 
                 # Should be fetched this way to ensure we don't get value from callback
-                prop_value = prop.value_no_call_back
+                if hasattr(prop, 'value_no_call_back'):
+                    # Property object
+                    prop_value = prop.value_no_call_back
+                else:
+                    # Descriptor object
+                    prop_value = prop.value
 
                 prop._callback = item.make_prop(item_key)
                 prop._callback.fset(prop_value)


### PR DESCRIPTION
Noticed when working on EDA.

This is a part of the large(r) slew of PRs for the new EasyDiffraction App update
