### PR TITLE
Dict size changed bug

### DIFF
--- a/src/easyscience/global_object/map.py
+++ b/src/easyscience/global_object/map.py
@@ -84,9 +84,13 @@ class Map:
             # If we hit a concurrent modification, create a safe copy
             # by iterating through items and collecting valid keys
             valid_keys = []
-            items = list(self._store.data.items()) if hasattr(self._store, 'data') else []
+            # Query all weak references to avoid modification during iteration
+            # WeakValueDictionary does not support items() directly, so we access the underlying data
+            items = list(self._store.data.items())
             for key, ref in items:
-                if ref() is not None:  # Only include keys with valid references
+                # Instantiating the weak reference to see if the object is still alive
+                # This test does not modify the dictionary
+                if ref() is not None:
                     valid_keys.append(key)
             return valid_keys
 

--- a/src/easyscience/global_object/map.py
+++ b/src/easyscience/global_object/map.py
@@ -76,7 +76,19 @@ class Map:
 
     def vertices(self) -> List[str]:
         """returns the vertices of a map"""
-        return list(self._store.keys())
+        # Create a copy to avoid "dictionary changed size during iteration" errors
+        # This can happen when objects are garbage collected during iteration
+        try:
+            return list(self._store.keys())
+        except RuntimeError:
+            # If we hit a concurrent modification, create a safe copy
+            # by iterating through items and collecting valid keys
+            valid_keys = []
+            items = list(self._store.data.items()) if hasattr(self._store, 'data') else []
+            for key, ref in items:
+                if ref() is not None:  # Only include keys with valid references
+                    valid_keys.append(key)
+            return valid_keys
 
     def edges(self):
         """returns the edges of a map"""


### PR DESCRIPTION
Fixed the `RuntimeError: dictionary changed size during iteration` issue in the `vertices` method by implementing thread-safety: iterations handling modifications during garbage collection.
This seems to have been a concurrency problem with weak references, where the dictionary is being modified during iteration.