### PR TITLE
Changed the finalizer function for __type_dict

### DIFF
--- a/src/easyscience/global_object/map.py
+++ b/src/easyscience/global_object/map.py
@@ -169,7 +169,7 @@ class Map:
         self._store[name] = obj
 
         entry_list = _EntryList()
-        entry_list.finalizer = weakref.finalize(obj, self.prune, name)
+        entry_list.finalizer = weakref.finalize(obj, self.prune_type_dict, name)
         entry_list.type = obj_type
         self.__type_dict[name] = entry_list  # Add objects type to the list of types
 
@@ -209,6 +209,10 @@ class Map:
 
         if vertex1 in self.__type_dict and vertex2 in self.__type_dict[vertex1]:
             del self.__type_dict[vertex1][self.__type_dict[vertex1].index(vertex2)]
+
+    def prune_type_dict(self, key: str):
+        if key in self.__type_dict:
+            del self.__type_dict[key]
 
     def prune(self, key: str):
         if key in self.__type_dict:


### PR DESCRIPTION
This is a temporary quickfix, until __type_dict is pruned from the codebase. The need for this change is due to serialization of baseobjects creating temprorary objects. When the temp objects are finally GC'd, their name in the _store dict might be already taken by an actual (not a temporary) Parameter. GC then calls the the __type_dict's finalizer. In the old solution it was the prune method, which removes the key from __type_dict as well as _store (which might be an actual Parameter by that time). The new solution provides a method to delete keys only from the __type_dict, since removing keys from _store might affect actual Parameters and since _store is a weakref dict anyway.