### PR TITLE
Relax scipp version constraint

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -34,6 +34,18 @@ platforms = ['win-64', 'linux-64', 'osx-64', 'osx-arm64']
 # Channels for fetching packages
 channels = ['conda-forge']
 
+#####################
+# SYSTEM REQUIREMENTS
+#####################
+
+[system-requirements]
+
+# Set minimum supported version for macOS to be 14.0 to ensure packages
+# like `skipp` that only have wheels for macOS 14.0+ (macosx_14_0_arm64)
+# are used instead of building from source. This is a workaround for
+# Pixi, see https://github.com/prefix-dev/pixi/issues/5667
+macos = '14.0'
+
 ##########
 # FEATURES
 ##########

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   'dfo-ls',        # Derivative-free optimization
   'uncertainties', # Propagation of uncertainties in calculations
   'numpy',         # Numerical computing
-  'scipp<26.1.0',  # Handling and analysis of scientific data
+  'scipp',         # Handling and analysis of scientific data
   'pooch',         # Data downloader
   'matplotlib',    # Plotting library
   'jupyterlab',    # Jupyter notebooks


### PR DESCRIPTION
This hotfix removes the upper version limit for the `scipp` dependency.