### PR TITLE
src\legacy should be in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ requires = ['hatchling', 'versioningit']
 
 [tool.hatch.build.targets.wheel]
 packages = ['src/easyscience']
-exclude = ['src/easyscience/legacy']
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
legacy projects still depend on components in src\easyscience\legacy
