### PR TITLE
Improved logging

### DIFF
--- a/docs/docs/user-guide/controlling-log-output.md
+++ b/docs/docs/user-guide/controlling-log-output.md
@@ -1,0 +1,200 @@
+# Controlling Log Output
+
+EasyScience uses Python's standard `logging` module for all
+informational and warning messages. This gives you full control over
+what output the library produces and where it goes.
+
+## Quick Start
+
+The most common operation is suppressing all EasyScience messages. You
+can do it in one line:
+
+```python
+from easyscience import global_object
+
+global_object.log.set_level('ERROR')
+```
+
+Or using the standard library directly:
+
+```python
+import logging
+
+logging.getLogger('easyscience').setLevel(logging.ERROR)
+```
+
+Both forms set the package-root logger to `ERROR`, which suppresses all
+`WARNING`, `INFO`, and `DEBUG` messages from EasyScience.
+
+## Logger Hierarchy
+
+EasyScience loggers are named hierarchically under the root
+`easyscience` logger. This lets you suppress the whole package or
+individual subsystems:
+
+```
+easyscience                        # root — controls everything
+├── easyscience.base_classes       # EasyList runtime warnings
+├── easyscience.legacy             # ObjBase / CollectionBase deprecations
+├── easyscience.deprecated         # @deprecated decorator messages
+├── easyscience.fitting            # import-availability warnings
+│   ├── easyscience.fitting.bumps  # Bumps fitting runtime messages
+│   ├── easyscience.fitting.lmfit  # LMFit fitting runtime messages
+│   └── easyscience.fitting.dfo    # DFO fitting runtime messages
+├── easyscience.variable           # parameter warnings
+└── easyscience.global_object      # undo/redo, debugging diagnostics
+```
+
+Setting the level on a parent logger affects all its children, because
+child loggers inherit the parent's effective level.
+
+```python
+import logging
+
+# Suppress everything from the fitting subsystem (including bumps/lmfit/dfo)
+logging.getLogger('easyscience.fitting').setLevel(logging.ERROR)
+
+# Suppress only Bumps runtime messages
+logging.getLogger('easyscience.fitting.bumps').setLevel(logging.ERROR)
+
+# Suppress only legacy deprecation notices
+logging.getLogger('easyscience.legacy').setLevel(logging.ERROR)
+```
+
+## Environment Variable
+
+You can control the log level **before** importing EasyScience by
+setting the `EASYSCIENCE_LOG_LEVEL` environment variable. This is useful
+when a downstream library cannot configure logging in code before
+EasyScience is imported.
+
+**Accepted values:** `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, or
+a numeric level (e.g. `40`).
+
+**Example — suppressing all import-time messages:**
+
+```powershell
+# Windows PowerShell
+$env:EASYSCIENCE_LOG_LEVEL = 'ERROR'
+python -c "import easyscience"  # silent
+```
+
+```bash
+# Linux / macOS
+EASYSCIENCE_LOG_LEVEL=ERROR python -c "import easyscience"  # silent
+```
+
+Or from Python, set the environment variable before the import:
+
+```python
+import os
+
+os.environ['EASYSCIENCE_LOG_LEVEL'] = 'ERROR'
+import easyscience  # now silent
+```
+
+## Temporary Suppression (Context Manager)
+
+When you only want to silence messages during a specific operation, use
+the `at_level` context manager:
+
+```python
+from easyscience import global_object
+import logging
+
+# Messages during the fit are suppressed, then the previous level is restored
+with global_object.log.at_level(logging.ERROR):
+    results = fitter.fit(x, y, weights)
+```
+
+This is the recommended pattern for technique-specific libraries that
+don't want EasyScience output to leak into their own users' consoles.
+
+## Convenience API
+
+The `global_object.log` object exposes convenience methods that mirror
+`logging` module-level functions:
+
+| Method              | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `.set_level(level)` | Set the package-root logger level (`'WARNING'` or `logging.WARNING`) |
+| `.debug(msg)`       | Log a `DEBUG`-level message                                          |
+| `.info(msg)`        | Log an `INFO`-level message                                          |
+| `.warning(msg)`     | Log a `WARNING`-level message                                        |
+| `.error(msg)`       | Log an `ERROR`-level message                                         |
+| `.critical(msg)`    | Log a `CRITICAL`-level message                                       |
+| `.exception(msg)`   | Log an `ERROR`-level message with traceback                          |
+| `.getLogger(name)`  | Get a child logger under `easyscience`                               |
+| `.at_level(level)`  | Context manager for temporary level change                           |
+| `.suspend()`        | Suppress all EasyScience output                                      |
+| `.resume()`         | Restore the previously set level                                     |
+
+## Recipes
+
+### Recipe 1: Keep your test output clean
+
+When running tests that exercise EasyScience fitting, suppress the
+library's messages so they don't clutter your test reports:
+
+```python
+import logging
+from easyscience import global_object
+
+@pytest.fixture(autouse=True)
+def _quiet_easyscience():
+    with global_object.log.at_level(logging.ERROR):
+        yield
+```
+
+### Recipe 2: Library author embedding EasyScience
+
+If you maintain a library that uses EasyScience internally, prevent
+EasyScience from writing to your users' consoles:
+
+```python
+# In your library's __init__.py, before any EasyScience import:
+import os
+os.environ.setdefault('EASYSCIENCE_LOG_LEVEL', 'ERROR')
+```
+
+### Recipe 3: Debug mode for development
+
+When developing or debugging, see all EasyScience internal diagnostics:
+
+```python
+from easyscience import global_object
+import logging
+
+global_object.log.set_level('DEBUG')
+
+# Your code here — all EasyScience messages will be visible
+```
+
+### Recipe 4: See only error messages
+
+Keep the console clean but still see critical problems:
+
+```python
+from easyscience import global_object
+
+global_object.log.set_level('ERROR')
+```
+
+## Library-Safe Behaviour
+
+EasyScience follows standard library-logging best practices:
+
+- **No `logging.basicConfig()`** — EasyScience never reconfigures the
+  global logging setup.
+- **No default stream handlers** — EasyScience does not attach handlers
+  that write to `stdout` or `stderr`. It only creates log records.
+  Applications and test frameworks decide where those records go.
+- **Child loggers inherit** — Child loggers (e.g.
+  `easyscience.fitting.bumps`) are left at `logging.NOTSET` by default,
+  so they inherit level and handler configuration from the `easyscience`
+  package-root logger. Supressing the root suppresses everything.
+
+This means you are in full control. If you don't configure any handlers,
+EasyScience messages will not appear. If you do configure handlers (as
+`pytest` does via its logging plugin, or as an application might via
+`basicConfig`), you control what is shown and where.

--- a/docs/docs/user-guide/controlling-log-output.md
+++ b/docs/docs/user-guide/controlling-log-output.md
@@ -12,7 +12,7 @@ can do it in one line:
 ```python
 from easyscience import global_object
 
-global_object.log.set_level('ERROR')
+global_object.log.level = 'ERROR'
 ```
 
 Or using the standard library directly:
@@ -112,22 +112,22 @@ don't want EasyScience output to leak into their own users' consoles.
 
 ## Convenience API
 
-The `global_object.log` object exposes convenience methods that mirror
-`logging` module-level functions:
+The `global_object.log` object exposes a `level` property plus
+convenience methods that mirror `logging` module-level functions:
 
-| Method              | Description                                                          |
-| ------------------- | -------------------------------------------------------------------- |
-| `.set_level(level)` | Set the package-root logger level (`'WARNING'` or `logging.WARNING`) |
-| `.debug(msg)`       | Log a `DEBUG`-level message                                          |
-| `.info(msg)`        | Log an `INFO`-level message                                          |
-| `.warning(msg)`     | Log a `WARNING`-level message                                        |
-| `.error(msg)`       | Log an `ERROR`-level message                                         |
-| `.critical(msg)`    | Log a `CRITICAL`-level message                                       |
-| `.exception(msg)`   | Log an `ERROR`-level message with traceback                          |
-| `.getLogger(name)`  | Get a child logger under `easyscience`                               |
-| `.at_level(level)`  | Context manager for temporary level change                           |
-| `.suspend()`        | Suppress all EasyScience output                                      |
-| `.resume()`         | Restore the previously set level                                     |
+| Member             | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| `.level`           | Get/set the package-root logger level (`'WARNING'` or `logging.WARNING`) |
+| `.debug(msg)`      | Log a `DEBUG`-level message                                              |
+| `.info(msg)`       | Log an `INFO`-level message                                              |
+| `.warning(msg)`    | Log a `WARNING`-level message                                            |
+| `.error(msg)`      | Log an `ERROR`-level message                                             |
+| `.critical(msg)`   | Log a `CRITICAL`-level message                                           |
+| `.exception(msg)`  | Log an `ERROR`-level message with traceback                              |
+| `.getLogger(name)` | Get a child logger under `easyscience`                                   |
+| `.at_level(level)` | Context manager for temporary level change                               |
+| `.suspend()`       | Suppress all EasyScience output                                          |
+| `.resume()`        | Restore the previously set level                                         |
 
 ## Recipes
 
@@ -164,7 +164,7 @@ When developing or debugging, see all EasyScience internal diagnostics:
 ```python
 from easyscience import global_object
 
-global_object.log.set_level('DEBUG')
+global_object.log.level = 'DEBUG'
 
 # Your code here — all EasyScience messages will be visible
 ```
@@ -176,7 +176,7 @@ Keep the console clean but still see critical problems:
 ```python
 from easyscience import global_object
 
-global_object.log.set_level('ERROR')
+global_object.log.level = 'ERROR'
 ```
 
 ## Library-Safe Behaviour

--- a/docs/docs/user-guide/controlling-log-output.md
+++ b/docs/docs/user-guide/controlling-log-output.md
@@ -142,6 +142,7 @@ from easyscience import global_object
 
 @pytest.fixture(autouse=True)
 def _quiet_easyscience():
+    # The test body runs *inside* the context manager (yield within `with`)
     with global_object.log.at_level(logging.ERROR):
         yield
 ```
@@ -194,6 +195,9 @@ EasyScience follows standard library-logging best practices:
   package-root logger. Supressing the root suppresses everything.
 
 This means you are in full control. If you don't configure any handlers,
-EasyScience messages will not appear. If you do configure handlers (as
-`pytest` does via its logging plugin, or as an application might via
-`basicConfig`), you control what is shown and where.
+Python's built-in `logging.lastResort` fallback still prints `WARNING`
+and above to `stderr`, so standalone users see important messages out of
+the box. `INFO` and `DEBUG` messages remain hidden until you opt in. If
+you do configure handlers (as `pytest` does via its logging plugin, or
+as an application might via `basicConfig`), you control what is shown
+and where.

--- a/docs/docs/user-guide/controlling-log-output.md
+++ b/docs/docs/user-guide/controlling-log-output.md
@@ -163,7 +163,6 @@ When developing or debugging, see all EasyScience internal diagnostics:
 
 ```python
 from easyscience import global_object
-import logging
 
 global_object.log.set_level('DEBUG')
 

--- a/docs/docs/user-guide/index.md
+++ b/docs/docs/user-guide/index.md
@@ -4,5 +4,7 @@ icon: material/book-open-variant
 
 # :material-book-open-variant: User Guide
 
-This section is currently under development. Please check back later for
-updates.
+- [:material-volume-high: Controlling Log Output](controlling-log-output.md)
+  – How to suppress, filter, or redirect the messages that EasyScience
+  produces. Covers the `EASYSCIENCE_LOG_LEVEL` environment variable, the
+  logger hierarchy, context managers, and common recipes.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - Installation & Setup: installation-and-setup/index.md
   - User Guide:
       - User Guide: user-guide/index.md
+      - Controlling Log Output: user-guide/controlling-log-output.md
   - Tutorials:
       - Tutorials: tutorials/index.md
       - Workshops & Schools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,8 @@ select = [
 # Ignore specific rules globally
 ignore = [
   'COM812', # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
-  # The following is replaced by 'D'/[tool.ruff.lint.pydocstyle] and [tool.pydoclint]  'DOC', # https://docs.astral.sh/ruff/rules/#pydoclint-doc
+  # The following is replaced by 'D'/[tool.ruff.lint.pydocstyle] and [tool.pydoclint]
+  'DOC', # https://docs.astral.sh/ruff/rules/#pydoclint-doc
   # Disable, as [tool.format_docstring] split one-line docstrings into the canonical multi-line layout
   'D200', # https://docs.astral.sh/ruff/rules/unnecessary-multiline-docstring/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,8 +211,7 @@ select = [
 # Ignore specific rules globally
 ignore = [
   'COM812', # https://docs.astral.sh/ruff/rules/missing-trailing-comma/
-  # The following is replaced by 'D'/[tool.ruff.lint.pydocstyle] and [tool.pydoclint]
-  'DOC', # https://docs.astral.sh/ruff/rules/#pydoclint-doc
+  # The following is replaced by 'D'/[tool.ruff.lint.pydocstyle] and [tool.pydoclint]  'DOC', # https://docs.astral.sh/ruff/rules/#pydoclint-doc
   # Disable, as [tool.format_docstring] split one-line docstrings into the canonical multi-line layout
   'D200', # https://docs.astral.sh/ruff/rules/unnecessary-multiline-docstring/
 ]

--- a/src/easyscience/base_classes/collection_base.py
+++ b/src/easyscience/base_classes/collection_base.py
@@ -13,5 +13,6 @@ from ..legacy.collection_base import CollectionBase  # noqa: F401
 
 global_object.log.warning(
     'easyscience.base_classes.collection_base is deprecated. '
-    'Please import from easyscience.legacy.collection_base instead.'
+    'Please import from easyscience.legacy.collection_base instead.',
+    stacklevel=2,
 )

--- a/src/easyscience/base_classes/collection_base.py
+++ b/src/easyscience/base_classes/collection_base.py
@@ -7,11 +7,11 @@
     Please update your imports.
 """
 
-import logging
+from easyscience import global_object
 
 from ..legacy.collection_base import CollectionBase  # noqa: F401
 
-logging.getLogger('easyscience').warning(
+global_object.log.warning(
     'easyscience.base_classes.collection_base is deprecated. '
     'Please import from easyscience.legacy.collection_base instead.'
 )

--- a/src/easyscience/base_classes/collection_base.py
+++ b/src/easyscience/base_classes/collection_base.py
@@ -7,13 +7,11 @@
     Please update your imports.
 """
 
-import warnings
+import logging
 
 from ..legacy.collection_base import CollectionBase  # noqa: F401
 
-warnings.warn(
+logging.getLogger('easyscience').warning(
     'easyscience.base_classes.collection_base is deprecated. '
-    'Please import from easyscience.legacy.collection_base instead.',
-    DeprecationWarning,
-    stacklevel=2,
+    'Please import from easyscience.legacy.collection_base instead.'
 )

--- a/src/easyscience/base_classes/easy_list.py
+++ b/src/easyscience/base_classes/easy_list.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 from collections.abc import MutableSequence
 from typing import Any
 from typing import Callable
@@ -16,6 +15,7 @@ from typing import Type
 from typing import TypeVar
 from typing import overload
 
+from easyscience import global_object
 from easyscience.io.serializer_base import SerializerBase
 from easyscience.variable.descriptor_base import DescriptorBase
 
@@ -159,7 +159,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
             if not isinstance(value, tuple(self._protected_types)):
                 raise TypeError(f'Items must be one of {self._protected_types}, got {type(value)}')
             if value is not self._data[idx] and value in self:
-                logging.getLogger('easyscience.base_classes').warning(
+                global_object.log.getLogger('base_classes').warning(
                     f'Item with unique name "{self._get_key(value)}" already in EasyList, it will be ignored'
                 )
                 return
@@ -177,7 +177,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
                 if not isinstance(v, tuple(self._protected_types)):
                     raise TypeError(f'Items must be one of {self._protected_types}, got {type(v)}')
                 if v in self and replaced[i] is not v:
-                    logging.getLogger('easyscience.base_classes').warning(
+                    global_object.log.getLogger('base_classes').warning(
                         f'Item with unique name "{v.unique_name}" already in EasyList, it will be ignored'
                     )
                     new_values[i] = replaced[
@@ -240,7 +240,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
         elif not isinstance(value, tuple(self._protected_types)):
             raise TypeError(f'Items must be one of {self._protected_types}, got {type(value)}')
         if value in self:
-            logging.getLogger('easyscience.base_classes').warning(
+            global_object.log.getLogger('base_classes').warning(
                 f'Item with unique name "{self._get_key(value)}" already in EasyList, it will be ignored'
             )
             return

--- a/src/easyscience/base_classes/easy_list.py
+++ b/src/easyscience/base_classes/easy_list.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import copy
-import warnings
+import logging
 from collections.abc import MutableSequence
 from typing import Any
 from typing import Callable
@@ -159,7 +159,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
             if not isinstance(value, tuple(self._protected_types)):
                 raise TypeError(f'Items must be one of {self._protected_types}, got {type(value)}')
             if value is not self._data[idx] and value in self:
-                warnings.warn(
+                logging.getLogger('easyscience.base_classes').warning(
                     f'Item with unique name "{self._get_key(value)}" already in EasyList, it will be ignored'
                 )
                 return
@@ -177,7 +177,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
                 if not isinstance(v, tuple(self._protected_types)):
                     raise TypeError(f'Items must be one of {self._protected_types}, got {type(v)}')
                 if v in self and replaced[i] is not v:
-                    warnings.warn(
+                    logging.getLogger('easyscience.base_classes').warning(
                         f'Item with unique name "{v.unique_name}" already in EasyList, it will be ignored'
                     )
                     new_values[i] = replaced[
@@ -240,7 +240,7 @@ class EasyList(ModelBase, MutableSequence[ProtectedType_]):
         elif not isinstance(value, tuple(self._protected_types)):
             raise TypeError(f'Items must be one of {self._protected_types}, got {type(value)}')
         if value in self:
-            warnings.warn(
+            logging.getLogger('easyscience.base_classes').warning(
                 f'Item with unique name "{self._get_key(value)}" already in EasyList, it will be ignored'
             )
             return

--- a/src/easyscience/base_classes/obj_base.py
+++ b/src/easyscience/base_classes/obj_base.py
@@ -7,11 +7,11 @@
     Please update your imports.
 """
 
-import logging
+from easyscience import global_object
 
 from ..legacy.obj_base import ObjBase  # noqa: F401
 
-logging.getLogger('easyscience').warning(
+global_object.log.warning(
     'easyscience.base_classes.obj_base is deprecated. '
     'Please import from easyscience.legacy.obj_base instead.'
 )

--- a/src/easyscience/base_classes/obj_base.py
+++ b/src/easyscience/base_classes/obj_base.py
@@ -13,5 +13,6 @@ from ..legacy.obj_base import ObjBase  # noqa: F401
 
 global_object.log.warning(
     'easyscience.base_classes.obj_base is deprecated. '
-    'Please import from easyscience.legacy.obj_base instead.'
+    'Please import from easyscience.legacy.obj_base instead.',
+    stacklevel=2,
 )

--- a/src/easyscience/base_classes/obj_base.py
+++ b/src/easyscience/base_classes/obj_base.py
@@ -7,13 +7,11 @@
     Please update your imports.
 """
 
-import warnings
+import logging
 
 from ..legacy.obj_base import ObjBase  # noqa: F401
 
-warnings.warn(
+logging.getLogger('easyscience').warning(
     'easyscience.base_classes.obj_base is deprecated. '
-    'Please import from easyscience.legacy.obj_base instead.',
-    DeprecationWarning,
-    stacklevel=2,
+    'Please import from easyscience.legacy.obj_base instead.'
 )

--- a/src/easyscience/fitting/available_minimizers.py
+++ b/src/easyscience/fitting/available_minimizers.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: 2024 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import logging
 from dataclasses import dataclass
 from enum import Enum
+
+from easyscience import global_object
 
 # Change to importlib.metadata when Python 3.10 is the minimum version
 # import importlib.metadata
@@ -15,7 +16,7 @@ try:
 
     lmfit_engine_available = True
 except ImportError:
-    logging.getLogger('easyscience.fitting').warning(
+    global_object.log.getLogger('fitting').warning(
         'LMFit minimization is not available. Probably lmfit has not been installed.'
     )
 
@@ -25,7 +26,7 @@ try:
 
     bumps_engine_available = True
 except ImportError:
-    logging.getLogger('easyscience.fitting').warning(
+    global_object.log.getLogger('fitting').warning(
         'Bumps minimization is not available. Probably bumps has not been installed.'
     )
 
@@ -35,7 +36,7 @@ try:
 
     dfo_engine_available = True
 except ImportError:
-    logging.getLogger('easyscience.fitting').warning(
+    global_object.log.getLogger('fitting').warning(
         'DFO minimization is not available. Probably dfols has not been installed.'
     )
 

--- a/src/easyscience/fitting/available_minimizers.py
+++ b/src/easyscience/fitting/available_minimizers.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 from dataclasses import dataclass
 from enum import Enum
 
@@ -15,11 +15,8 @@ try:
 
     lmfit_engine_available = True
 except ImportError:
-    # TODO make this a proper message (use logging?)
-    warnings.warn(
-        'LMFit minimization is not available. Probably lmfit has not been installed.',
-        ImportWarning,
-        stacklevel=2,
+    logging.getLogger('easyscience.fitting').warning(
+        'LMFit minimization is not available. Probably lmfit has not been installed.'
     )
 
 bumps_engine_available = False
@@ -28,11 +25,8 @@ try:
 
     bumps_engine_available = True
 except ImportError:
-    # TODO make this a proper message (use logging?)
-    warnings.warn(
-        'Bumps minimization is not available. Probably bumps has not been installed.',
-        ImportWarning,
-        stacklevel=2,
+    logging.getLogger('easyscience.fitting').warning(
+        'Bumps minimization is not available. Probably bumps has not been installed.'
     )
 
 dfo_engine_available = False
@@ -41,11 +35,8 @@ try:
 
     dfo_engine_available = True
 except ImportError:
-    # TODO make this a proper message (use logging?)
-    warnings.warn(
-        'DFO minimization is not available. Probably dfols has not been installed.',
-        ImportWarning,
-        stacklevel=2,
+    logging.getLogger('easyscience.fitting').warning(
+        'DFO minimization is not available. Probably dfols has not been installed.'
     )
 
 

--- a/src/easyscience/fitting/calculators/interface_factory.py
+++ b/src/easyscience/fitting/calculators/interface_factory.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -11,6 +10,8 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Type
+
+from easyscience import global_object
 
 if TYPE_CHECKING:
     from abc import ABCMeta
@@ -97,14 +98,14 @@ class InterfaceFactoryTemplate:
                     if hasattr(obj, 'update_bindings'):
                         obj.update_bindings()
                 except Exception as e:
-                    logging.getLogger('easyscience.fitting.calculators').warning(
+                    global_object.log.getLogger('fitting.calculators').warning(
                         'Unable to auto generate bindings.\n%s', e
                     )
             elif hasattr(fitter, 'generate_bindings'):
                 try:
                     fitter.generate_bindings()
                 except Exception as e:
-                    logging.getLogger('easyscience.fitting.calculators').warning(
+                    global_object.log.getLogger('fitting.calculators').warning(
                         'Unable to auto generate bindings.\n%s', e
                     )
 

--- a/src/easyscience/fitting/calculators/interface_factory.py
+++ b/src/easyscience/fitting/calculators/interface_factory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -96,12 +97,16 @@ class InterfaceFactoryTemplate:
                     if hasattr(obj, 'update_bindings'):
                         obj.update_bindings()
                 except Exception as e:
-                    print(f'Unable to auto generate bindings.\n{e}')
+                    logging.getLogger('easyscience.fitting.calculators').warning(
+                        'Unable to auto generate bindings.\n%s', e
+                    )
             elif hasattr(fitter, 'generate_bindings'):
                 try:
                     fitter.generate_bindings()
                 except Exception as e:
-                    print(f'Unable to auto generate bindings.\n{e}')
+                    logging.getLogger('easyscience.fitting.calculators').warning(
+                        'Unable to auto generate bindings.\n%s', e
+                    )
 
     @property
     def available_interfaces(self) -> List[str]:

--- a/src/easyscience/fitting/fitter.py
+++ b/src/easyscience/fitting/fitter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
+import logging
 from typing import Callable
 from typing import List
 from typing import Optional
@@ -72,7 +73,9 @@ class Fitter:
             DEFAULT_MINIMIZER.
         """
         if isinstance(minimizer_enum, str):
-            print(f'minimizer should be set with enum {minimizer_enum}')
+            logging.getLogger('easyscience.fitting').warning(
+                'minimizer should be set with enum %s', minimizer_enum
+            )
             minimizer_enum = from_string_to_enum(minimizer_enum)
         self._update_minimizer(minimizer_enum)
 
@@ -86,7 +89,9 @@ class Fitter:
             The enum of the minimizer to create and instantiate.
         """
         if isinstance(minimizer_enum, str):
-            print(f'minimizer should be set with enum {minimizer_enum}')
+            logging.getLogger('easyscience.fitting').warning(
+                'minimizer should be set with enum %s', minimizer_enum
+            )
             minimizer_enum = from_string_to_enum(minimizer_enum)
 
         self._update_minimizer(minimizer_enum)

--- a/src/easyscience/fitting/fitter.py
+++ b/src/easyscience/fitting/fitter.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
-import logging
 from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Union
 
 import numpy as np
+
+from easyscience import global_object
 
 from .available_minimizers import AvailableMinimizers
 from .available_minimizers import from_string_to_enum
@@ -73,7 +74,7 @@ class Fitter:
             DEFAULT_MINIMIZER.
         """
         if isinstance(minimizer_enum, str):
-            logging.getLogger('easyscience.fitting').warning(
+            global_object.log.getLogger('fitting').warning(
                 'minimizer should be set with enum %s', minimizer_enum
             )
             minimizer_enum = from_string_to_enum(minimizer_enum)
@@ -89,7 +90,7 @@ class Fitter:
             The enum of the minimizer to create and instantiate.
         """
         if isinstance(minimizer_enum, str):
-            logging.getLogger('easyscience.fitting').warning(
+            global_object.log.getLogger('fitting').warning(
                 'minimizer should be set with enum %s', minimizer_enum
             )
             minimizer_enum = from_string_to_enum(minimizer_enum)

--- a/src/easyscience/fitting/minimizers/minimizer_bumps.py
+++ b/src/easyscience/fitting/minimizers/minimizer_bumps.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
-import logging
 from typing import Any
 from typing import Callable
 from typing import List
@@ -484,14 +483,16 @@ class Bumps(MinimizerBase):
                 f'objective evaluated {n_evaluations} times'
             )
         if stopped_on_budget:
+            from easyscience import global_object
+
             if tolerance is None:
-                logging.getLogger('easyscience.fitting.bumps').warning(
+                global_object.log.getLogger('fitting.bumps').warning(
                     f'Fit did not converge within the maximum optimizer steps of {max_evaluations} '
                     f'({n_evaluations} objective evaluations). '
                     'Consider increasing the maximum number of evaluations or adjusting the tolerance.'
                 )
             else:
-                logging.getLogger('easyscience.fitting.bumps').warning(
+                global_object.log.getLogger('fitting.bumps').warning(
                     f'Fit did not reach the desired tolerance of {tolerance} within the maximum optimizer steps of {max_evaluations} '
                     f'({n_evaluations} objective evaluations). '
                     'Consider increasing the maximum number of evaluations or adjusting the tolerance.'

--- a/src/easyscience/fitting/minimizers/minimizer_bumps.py
+++ b/src/easyscience/fitting/minimizers/minimizer_bumps.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
-import warnings
+import logging
 from typing import Any
 from typing import Callable
 from typing import List
@@ -485,18 +485,16 @@ class Bumps(MinimizerBase):
             )
         if stopped_on_budget:
             if tolerance is None:
-                warnings.warn(
+                logging.getLogger('easyscience.fitting.bumps').warning(
                     f'Fit did not converge within the maximum optimizer steps of {max_evaluations} '
                     f'({n_evaluations} objective evaluations). '
-                    'Consider increasing the maximum number of evaluations or adjusting the tolerance.',
-                    UserWarning,
+                    'Consider increasing the maximum number of evaluations or adjusting the tolerance.'
                 )
             else:
-                warnings.warn(
+                logging.getLogger('easyscience.fitting.bumps').warning(
                     f'Fit did not reach the desired tolerance of {tolerance} within the maximum optimizer steps of {max_evaluations} '
                     f'({n_evaluations} objective evaluations). '
-                    'Consider increasing the maximum number of evaluations or adjusting the tolerance.',
-                    UserWarning,
+                    'Consider increasing the maximum number of evaluations or adjusting the tolerance.'
                 )
 
         # results.residual = results.y_obs - results.y_calc

--- a/src/easyscience/fitting/minimizers/minimizer_dfo.py
+++ b/src/easyscience/fitting/minimizers/minimizer_dfo.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import logging
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
@@ -393,6 +392,8 @@ class DFO(MinimizerBase):
         """
 
         results = FitResults()
+        from easyscience import global_object
+
         for name, value in kwargs.items():
             if getattr(results, name, False):
                 setattr(results, name, value)
@@ -400,7 +401,7 @@ class DFO(MinimizerBase):
         # EXIT_SUCCESS is 0 and EXIT_MAXFUN_WARNING keeps a different flag value.
         results.success = fit_results.flag == fit_results.EXIT_SUCCESS
         if fit_results.flag == fit_results.EXIT_MAXFUN_WARNING:
-            logging.getLogger('easyscience.fitting.dfo').warning(str(fit_results.msg))
+            global_object.log.getLogger('fitting.dfo').warning(str(fit_results.msg))
 
         pars = {}
         for p_name, par in self._cached_pars.items():
@@ -419,7 +420,7 @@ class DFO(MinimizerBase):
         results.message = str(fit_results.msg)
         if not results.success:
             warning_message = results.message or 'DFO fit did not succeed.'
-            logging.getLogger('easyscience.fitting.dfo').warning(warning_message)
+            global_object.log.getLogger('fitting.dfo').warning(warning_message)
         # results.residual = results.y_obs - results.y_calc
         # results.goodness_of_fit = fit_results.f
 

--- a/src/easyscience/fitting/minimizers/minimizer_dfo.py
+++ b/src/easyscience/fitting/minimizers/minimizer_dfo.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
@@ -400,7 +400,7 @@ class DFO(MinimizerBase):
         # EXIT_SUCCESS is 0 and EXIT_MAXFUN_WARNING keeps a different flag value.
         results.success = fit_results.flag == fit_results.EXIT_SUCCESS
         if fit_results.flag == fit_results.EXIT_MAXFUN_WARNING:
-            warnings.warn(str(fit_results.msg), UserWarning)
+            logging.getLogger('easyscience.fitting.dfo').warning(str(fit_results.msg))
 
         pars = {}
         for p_name, par in self._cached_pars.items():
@@ -419,7 +419,7 @@ class DFO(MinimizerBase):
         results.message = str(fit_results.msg)
         if not results.success:
             warning_message = results.message or 'DFO fit did not succeed.'
-            warnings.warn(warning_message, UserWarning, stacklevel=2)
+            logging.getLogger('easyscience.fitting.dfo').warning(warning_message)
         # results.residual = results.y_obs - results.y_calc
         # results.goodness_of_fit = fit_results.f
 

--- a/src/easyscience/fitting/minimizers/minimizer_lmfit.py
+++ b/src/easyscience/fitting/minimizers/minimizer_lmfit.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 from typing import Any
 from typing import Callable
 from typing import List
@@ -413,7 +413,7 @@ class LMFit(MinimizerBase):  # noqa: S101
         results.iterations = kwargs.get('iterations')
         results.message = fit_results.message
         if fit_results.success is False and fit_results.message:
-            warnings.warn(str(fit_results.message), UserWarning)
+            logging.getLogger('easyscience.fitting.lmfit').warning(str(fit_results.message))
         results.minimizer_engine = self.__class__
         results.fit_args = None
 

--- a/src/easyscience/fitting/minimizers/minimizer_lmfit.py
+++ b/src/easyscience/fitting/minimizers/minimizer_lmfit.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import logging
 from typing import Any
 from typing import Callable
 from typing import List
@@ -413,7 +412,9 @@ class LMFit(MinimizerBase):  # noqa: S101
         results.iterations = kwargs.get('iterations')
         results.message = fit_results.message
         if fit_results.success is False and fit_results.message:
-            logging.getLogger('easyscience.fitting.lmfit').warning(str(fit_results.message))
+            from easyscience import global_object
+
+            global_object.log.getLogger('fitting.lmfit').warning(str(fit_results.message))
         results.minimizer_engine = self.__class__
         results.fit_args = None
 

--- a/src/easyscience/global_object/hugger/property.py
+++ b/src/easyscience/global_object/hugger/property.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
+import logging
 import sys
 from functools import wraps
 from typing import Any
@@ -73,7 +74,9 @@ class LoggedProperty(property):
                     result_item(item)
             Store().append_log(self.makeEntry('get', res))
             if global_object.debug:  # noqa: S1006
-                print(f"I'm {self._my_self} and {self._get_id} has been called from the outside!")
+                logging.getLogger('easyscience.global_object.hugger').debug(
+                    "I'm %s and %s has been called from the outside!", self._my_self, self._get_id
+                )
         return res
 
     def __set__(self, instance, value):
@@ -83,8 +86,9 @@ class LoggedProperty(property):
         if not test and self._get_id is not None and self._my_self is not None:
             Store().append_log(self.makeEntry('set', value))
             if global_object.debug:  # noqa: S1006
-                print(
-                    f"I'm {self._my_self} and {self._get_id} has been set to {value} from the outside!"
+                logging.getLogger('easyscience.global_object.hugger').debug(
+                    "I'm %s and %s has been set to %s from the outside!",
+                    self._my_self, self._get_id, value
                 )
         return super().__set__(instance, value)
 
@@ -131,7 +135,9 @@ class LoggedProperty(property):
                         var = '"' + var + '"'
                     temp += f'{var}'
         else:
-            print(f'{log_type} is not implemented yet. Sorry')
+            logging.getLogger('easyscience.global_object.hugger').debug(
+                '%s is not implemented yet. Sorry', log_type
+            )
         temp += '\n'
         return temp
 
@@ -163,7 +169,9 @@ class PropertyHugger(PatcherFactory):
             func = getattr(self.property, key)
             if func is not None:
                 if global_object.debug:
-                    print(f'Patching property {self.klass.__name__}.{self.prop_name}')
+                    logging.getLogger('easyscience.global_object.hugger').debug(
+                        'Patching property %s.%s', self.klass.__name__, self.prop_name
+                    )
                 patch_function: Callable = item.get('patcher')
                 new_func = patch_function(func)
                 option[key] = new_func
@@ -171,7 +179,9 @@ class PropertyHugger(PatcherFactory):
 
     def restore(self):
         if global_object.debug:
-            print(f'Restoring property {self.klass.__name__}.{self.prop_name}')
+            logging.getLogger('easyscience.global_object.hugger').debug(
+                'Restoring property %s.%s', self.klass.__name__, self.prop_name
+            )
         setattr(self.klass, self.prop_name, self.property)
 
     def patch_get(self, func: Callable) -> Callable:
@@ -179,8 +189,9 @@ class PropertyHugger(PatcherFactory):
         @wraps(func)
         def inner(*args, **kwargs):
             if global_object.debug:
-                print(
-                    f'{self.klass.__name__}.{self.prop_name} has been called with {args[1:]}, {kwargs}'
+                logging.getLogger('easyscience.global_object.hugger').debug(
+                    '%s.%s has been called with %s, %s',
+                    self.klass.__name__, self.prop_name, args[1:], kwargs
                 )
             res = func(*args, **kwargs)
             self._append_args(*args, **kwargs)
@@ -195,8 +206,9 @@ class PropertyHugger(PatcherFactory):
         @wraps(func)
         def inner(*args, **kwargs):
             if global_object.debug:
-                print(
-                    f'{self.klass.__name__}.{self.prop_name} has been set with {args[1:]}, {kwargs}'
+                logging.getLogger('easyscience.global_object.hugger').debug(
+                    '%s.%s has been set with %s, %s',
+                    self.klass.__name__, self.prop_name, args[1:], kwargs
                 )
             self._append_args(*args, **kwargs)
             self._append_log(self.makeEntry('set', None, *args, **kwargs))
@@ -209,7 +221,9 @@ class PropertyHugger(PatcherFactory):
         @wraps(func)
         def inner(*args, **kwargs):
             if global_object.debug:
-                print(f'{self.klass.__name__}.{self.prop_name} has been deleted.')
+                logging.getLogger('easyscience.global_object.hugger').debug(
+                    '%s.%s has been deleted.', self.klass.__name__, self.prop_name
+                )
             self._append_log(self.makeEntry('del', None, *args, **kwargs))
             return func(*args, **kwargs)
 
@@ -252,6 +266,8 @@ class PropertyHugger(PatcherFactory):
                         var = '"' + var + '"'
                     temp += f'{var}'
         else:
-            print(f'{log_type} is not implemented yet. Sorry')
+            logging.getLogger('easyscience.global_object.hugger').debug(
+                '%s is not implemented yet. Sorry', log_type
+            )
         temp += '\n'
         return temp

--- a/src/easyscience/global_object/hugger/property.py
+++ b/src/easyscience/global_object/hugger/property.py
@@ -88,7 +88,9 @@ class LoggedProperty(property):
             if global_object.debug:  # noqa: S1006
                 logging.getLogger('easyscience.global_object.hugger').debug(
                     "I'm %s and %s has been set to %s from the outside!",
-                    self._my_self, self._get_id, value
+                    self._my_self,
+                    self._get_id,
+                    value,
                 )
         return super().__set__(instance, value)
 
@@ -191,7 +193,10 @@ class PropertyHugger(PatcherFactory):
             if global_object.debug:
                 logging.getLogger('easyscience.global_object.hugger').debug(
                     '%s.%s has been called with %s, %s',
-                    self.klass.__name__, self.prop_name, args[1:], kwargs
+                    self.klass.__name__,
+                    self.prop_name,
+                    args[1:],
+                    kwargs,
                 )
             res = func(*args, **kwargs)
             self._append_args(*args, **kwargs)
@@ -208,7 +213,10 @@ class PropertyHugger(PatcherFactory):
             if global_object.debug:
                 logging.getLogger('easyscience.global_object.hugger').debug(
                     '%s.%s has been set with %s, %s',
-                    self.klass.__name__, self.prop_name, args[1:], kwargs
+                    self.klass.__name__,
+                    self.prop_name,
+                    args[1:],
+                    kwargs,
                 )
             self._append_args(*args, **kwargs)
             self._append_log(self.makeEntry('set', None, *args, **kwargs))

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -18,20 +18,28 @@ _LEVEL_NAME_MAP = {
 }
 
 
-def _resolve_log_level(
-    raw: str | None,
-    default: int = logging.WARNING,
-) -> int:
-    """Parse an environment-variable string into a logging level."""
-    if raw is None:
-        return default
-    stripped = raw.strip()
+def _parse_log_level(level: int | str) -> int:
+    """Convert a level number or name into a numeric level, raising on an unknown name."""
+    if isinstance(level, int):
+        return level
+    stripped = level.strip()
     if stripped.isdigit():
         return int(stripped)
     upper = stripped.upper()
     if upper in _LEVEL_NAME_MAP:
         return _LEVEL_NAME_MAP[upper]
-    return default
+    valid = ', '.join(sorted(_LEVEL_NAME_MAP))
+    raise ValueError(f'Unknown log level {level!r}. Expected an integer or one of: {valid}.')
+
+
+def _env_log_level(raw: str | None, default: int) -> int:
+    """Parse the EASYSCIENCE_LOG_LEVEL env var, falling back to *default* on an unset/bad value."""
+    if raw is None:
+        return default
+    try:
+        return _parse_log_level(raw)
+    except ValueError:
+        return default
 
 
 class Logger:
@@ -52,12 +60,10 @@ class Logger:
             Default level for the package-root logger. Overridden by the
             ``EASYSCIENCE_LOG_LEVEL`` environment variable when set.
         """
-        self._effective_default = _resolve_log_level(
-            os.environ.get(_LOG_LEVEL_ENV_VAR), default=log_level
-        )
+        effective_default = _env_log_level(os.environ.get(_LOG_LEVEL_ENV_VAR), default=log_level)
         self.logger = logging.getLogger(PACKAGE_LOGGER_NAME)
-        self.logger.setLevel(self._effective_default)
-        self.level = self._effective_default
+        self.logger.setLevel(effective_default)
+        self._level_before_suspend = effective_default
 
     # -- convenience delegation methods (mirror logging module) ------------
 
@@ -87,18 +93,32 @@ class Logger:
 
     # -- public API -------------------------------------------------------
 
-    def set_level(self, level: int | str) -> None:
+    @property
+    def level(self) -> int:
         """
-        Set the effective level of the package-root logger.
+        Get the effective level of the package-root logger.
+
+        Returns
+        -------
+        int
+            Numeric logging level currently set on the ``easyscience``
+            package-root logger.
+        """
+        return self.logger.level
+
+    @level.setter
+    def level(self, value: int | str) -> None:
+        """
+        Set the level of the package-root logger.
 
         Parameters
         ----------
-        level : int | str
-            Logging level — e.g. ``logging.WARNING``, ``'ERROR'``.
+        value : int | str
+            Logging level — a number (e.g. ``logging.WARNING``) or a
+            level name (e.g. ``'ERROR'``). A string that is not a
+            recognised level name or numeric string raises ``ValueError``.
         """
-        resolved_level = _resolve_log_level(level) if isinstance(level, str) else level
-        self.level = resolved_level
-        self.logger.setLevel(resolved_level)
+        self.logger.setLevel(_parse_log_level(value))
 
     def getLogger(self, logger_name: str) -> logging.Logger:
         """
@@ -150,22 +170,20 @@ class Logger:
             fitter.fit(x, y, weights)  # no core messages below ERROR
         ```
         """
-        previous = self.level
-        resolved_level = _resolve_log_level(level) if isinstance(level, str) else level
-        self.level = resolved_level
-        self.logger.setLevel(resolved_level)
+        previous = self.logger.level
+        self.level = level
         try:
             yield
         finally:
-            self.level = previous
             self.logger.setLevel(previous)
 
     # -- deprecated helpers (compatibility shims) -------------------------
 
     def suspend(self):
         """Suppress all core log output (set level to CRITICAL+1)."""
+        self._level_before_suspend = self.logger.level
         self.logger.setLevel(logging.CRITICAL + 1)
 
     def resume(self):
-        """Restore the previously configured log level."""
-        self.logger.setLevel(self.level)
+        """Restore the level captured by the most recent suspend call."""
+        self.level = self._level_before_suspend

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -20,16 +20,19 @@ _LEVEL_NAME_MAP = {
 
 def _parse_log_level(level: int | str) -> int:
     """Convert a level number or name into a numeric level, raising on an unknown name."""
-    if isinstance(level, int):
-        return level
-    stripped = level.strip()
-    if stripped.isdigit():
-        return int(stripped)
-    upper = stripped.upper()
-    if upper in _LEVEL_NAME_MAP:
-        return _LEVEL_NAME_MAP[upper]
-    valid = ', '.join(sorted(_LEVEL_NAME_MAP))
-    raise ValueError(f'Unknown log level {level!r}. Expected an integer or one of: {valid}.')
+    if isinstance(level, str):
+        stripped = level.strip()
+        if stripped.isdigit():
+            return int(stripped)
+        upper = stripped.upper()
+        if upper in _LEVEL_NAME_MAP:
+            return _LEVEL_NAME_MAP[upper]
+        valid = ', '.join(sorted(_LEVEL_NAME_MAP))
+        raise ValueError(f'Unknown log level {level!r}. Expected an integer or one of: {valid}.')
+    # bool is a subclass of int, so reject it explicitly before accepting ints.
+    if isinstance(level, bool) or not isinstance(level, int):
+        raise TypeError(f'Log level must be int or str, not {type(level).__name__}')
+    return level
 
 
 def _env_log_level(raw: str | None, default: int) -> int:

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -56,8 +56,9 @@ class Logger:
     """
 
     def __init__(self, log_level: int = logging.WARNING):
-        env_level = _resolve_log_level(os.environ.get(_LOG_LEVEL_ENV_VAR))
-        self._effective_default = env_level if env_level is not None else log_level
+        self._effective_default = _resolve_log_level(
+            os.environ.get(_LOG_LEVEL_ENV_VAR), default=log_level
+        )
         self.logger = logging.getLogger(PACKAGE_LOGGER_NAME)
         self.logger.setLevel(self._effective_default)
         self.level = self._effective_default
@@ -104,12 +105,7 @@ class Logger:
         self.level = level
         self.logger.setLevel(level)
 
-    def getLogger(
-        self,
-        logger_name: str,
-        color: str = '32',
-        defaults: bool = True,
-    ) -> logging.Logger:
+    def getLogger(self, logger_name: str) -> logging.Logger:
         """
         Create or retrieve a child logger under *easyscience*.
 
@@ -120,12 +116,6 @@ class Logger:
         ----------
         logger_name : str
             Logger name. Usually ``__name__`` of the calling module.
-        color : str, default='32'
-            Historical color parameter (currently unused, preserved for
-            compatibility).
-        defaults : bool, default=True
-            Historical defaults flag (currently unused, preserved for
-            compatibility).
 
         Returns
         -------
@@ -152,10 +142,12 @@ class Logger:
         previous = self.level
         if isinstance(level, str):
             level = _resolve_log_level(level)
+        self.level = level
         self.logger.setLevel(level)
         try:
             yield
         finally:
+            self.level = previous
             self.logger.setLevel(previous)
 
     # -- deprecated helpers (compatibility shims) -------------------------

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -19,7 +19,8 @@ _LEVEL_NAME_MAP = {
 
 
 def _resolve_log_level(
-    raw: Optional[str], default: int = logging.WARNING,
+    raw: Optional[str],
+    default: int = logging.WARNING,
 ) -> int:
     """Parse an environment-variable string into a logging level."""
     if raw is None:
@@ -104,7 +105,10 @@ class Logger:
         self.logger.setLevel(level)
 
     def getLogger(
-        self, logger_name: str, color: str = '32', defaults: bool = True,
+        self,
+        logger_name: str,
+        color: str = '32',
+        defaults: bool = True,
     ) -> logging.Logger:
         """
         Create or retrieve a child logger under *easyscience*.

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -1,44 +1,165 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
+import contextlib
 import logging
+import os
+from typing import Optional
+
+PACKAGE_LOGGER_NAME = 'easyscience'
+_LOG_LEVEL_ENV_VAR = 'EASYSCIENCE_LOG_LEVEL'
+
+_LEVEL_NAME_MAP = {
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL,
+}
+
+
+def _resolve_log_level(
+    raw: Optional[str], default: int = logging.WARNING,
+) -> int:
+    """Parse an environment-variable string into a logging level."""
+    if raw is None:
+        return default
+    stripped = raw.strip()
+    if stripped.isdigit():
+        return int(stripped)
+    upper = stripped.upper()
+    if upper in _LEVEL_NAME_MAP:
+        return _LEVEL_NAME_MAP[upper]
+    return default
 
 
 class Logger:
-    def __init__(self, log_level: int = logging.INFO):
-        self.logger = logging.getLogger(__name__)
-        self.level = log_level
-        self.logger.setLevel(self.level)
+    """
+    Central logging controller for EasyScience.
+
+    Owns the package-root logger ``easyscience`` and provides a
+    convenience API to set its level.
+
+    Library-safe behaviour:
+    - Never calls :func:`logging.basicConfig`.
+    - Never attaches a default stream handler.
+    - Child loggers returned by :meth:`getLogger` are left at
+      ``logging.NOTSET`` so they inherit level control from the package
+      root logger.
+
+    Parameters
+    ----------
+    log_level : int, default=logging.WARNING
+        Default level for the package-root logger. Overridden by the
+        ``EASYSCIENCE_LOG_LEVEL`` environment variable when set.
+    """
+
+    def __init__(self, log_level: int = logging.WARNING):
+        env_level = _resolve_log_level(os.environ.get(_LOG_LEVEL_ENV_VAR))
+        self._effective_default = env_level if env_level is not None else log_level
+        self.logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+        self.logger.setLevel(self._effective_default)
+        self.level = self._effective_default
+
+    # -- convenience delegation methods (mirror logging module) ------------
+
+    def debug(self, msg: str, *args, **kwargs) -> None:
+        """Log a DEBUG-level message on the package-root logger."""
+        self.logger.debug(msg, *args, **kwargs)
+
+    def info(self, msg: str, *args, **kwargs) -> None:
+        """Log an INFO-level message on the package-root logger."""
+        self.logger.info(msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args, **kwargs) -> None:
+        """Log a WARNING-level message on the package-root logger."""
+        self.logger.warning(msg, *args, **kwargs)
+
+    def error(self, msg: str, *args, **kwargs) -> None:
+        """Log an ERROR-level message on the package-root logger."""
+        self.logger.error(msg, *args, **kwargs)
+
+    def critical(self, msg: str, *args, **kwargs) -> None:
+        """Log a CRITICAL-level message on the package-root logger."""
+        self.logger.critical(msg, *args, **kwargs)
+
+    def exception(self, msg: str, *args, **kwargs) -> None:
+        """Log an ERROR-level message with traceback on the package-root logger."""
+        self.logger.exception(msg, *args, **kwargs)
+
+    # -- public API -------------------------------------------------------
+
+    def set_level(self, level: int | str) -> None:
+        """
+        Set the effective level of the package-root logger.
+
+        Parameters
+        ----------
+        level : int | str
+            Logging level — e.g. ``logging.WARNING``, ``'ERROR'``.
+        """
+        if isinstance(level, str):
+            level = _resolve_log_level(level)
+        self.level = level
+        self.logger.setLevel(level)
 
     def getLogger(
-        self, logger_name: str, color: str = '32', defaults: bool = True
+        self, logger_name: str, color: str = '32', defaults: bool = True,
     ) -> logging.Logger:
         """
-        Create a logger :param color:.
+        Create or retrieve a child logger under *easyscience*.
+
+        The returned logger is left at ``logging.NOTSET`` so it inherits
+        level and handler configuration from the package-root logger.
 
         Parameters
         ----------
         logger_name : str
-            Logger name. Usually __name__ on creation.
+            Logger name. Usually ``__name__`` of the calling module.
         color : str, default='32'
-            By default, '32'.
+            Historical color parameter (currently unused, preserved for
+            compatibility).
         defaults : bool, default=True
-            Do you want to associate any current file loggers with this
-            logger. By default, True.
+            Historical defaults flag (currently unused, preserved for
+            compatibility).
 
         Returns
         -------
         logging.Logger
-            A logger.
+            A child logger whose name is ``easyscience.<logger_name>``
+            when *logger_name* does not already start with *easyscience*
+            or a dot.
         """
-        logger = logging.getLogger(logger_name)
-        logger.setLevel(self.level)
-        # self.applyLevel(logger)
-        # for handler_type in self._handlers:
-        #     for handler in self._handlers[handler_type]:
-        #         if handler_type == 'sys' or defaults:
-        #             handler.formatter._fmt = self._makeColorText(color)
-        #             logger.addHandler(handler)
-        # logger.propagate = False
-        # self._loggers.append(logger)
-        return logger
+        if not logger_name.startswith('easyscience') and not logger_name.startswith('.'):
+            logger_name = f'{PACKAGE_LOGGER_NAME}.{logger_name}'
+        return logging.getLogger(logger_name)
+
+    @contextlib.contextmanager
+    def at_level(self, level: int | str):
+        """
+        Context manager that temporarily sets the package-root logger
+        to *level*, restoring the previous level on exit.
+
+        Example::
+
+            with global_object.log.at_level(logging.ERROR):
+                fitter.fit(x, y, weights)  # no core messages below ERROR
+        """
+        previous = self.level
+        if isinstance(level, str):
+            level = _resolve_log_level(level)
+        self.logger.setLevel(level)
+        try:
+            yield
+        finally:
+            self.logger.setLevel(previous)
+
+    # -- deprecated helpers (compatibility shims) -------------------------
+
+    def suspend(self):
+        """Suppress all core log output (set level to CRITICAL+1)."""
+        self.logger.setLevel(logging.CRITICAL + 1)
+
+    def resume(self):
+        """Restore the previously configured log level."""
+        self.logger.setLevel(self.level)

--- a/src/easyscience/global_object/logger.py
+++ b/src/easyscience/global_object/logger.py
@@ -4,7 +4,7 @@
 import contextlib
 import logging
 import os
-from typing import Optional
+from collections.abc import Iterator
 
 PACKAGE_LOGGER_NAME = 'easyscience'
 _LOG_LEVEL_ENV_VAR = 'EASYSCIENCE_LOG_LEVEL'
@@ -19,7 +19,7 @@ _LEVEL_NAME_MAP = {
 
 
 def _resolve_log_level(
-    raw: Optional[str],
+    raw: str | None,
     default: int = logging.WARNING,
 ) -> int:
     """Parse an environment-variable string into a logging level."""
@@ -39,23 +39,19 @@ class Logger:
     Central logging controller for EasyScience.
 
     Owns the package-root logger ``easyscience`` and provides a
-    convenience API to set its level.
-
-    Library-safe behaviour:
-    - Never calls :func:`logging.basicConfig`.
-    - Never attaches a default stream handler.
-    - Child loggers returned by :meth:`getLogger` are left at
-      ``logging.NOTSET`` so they inherit level control from the package
-      root logger.
-
-    Parameters
-    ----------
-    log_level : int, default=logging.WARNING
-        Default level for the package-root logger. Overridden by the
-        ``EASYSCIENCE_LOG_LEVEL`` environment variable when set.
+    convenience API to set its level. It never calls
+    ``logging.basicConfig`` nor attaches a handler, so the host
+    application keeps full control over where output goes.
     """
 
     def __init__(self, log_level: int = logging.WARNING):
+        """
+        Parameters
+        ----------
+        log_level : int, default=logging.WARNING
+            Default level for the package-root logger. Overridden by the
+            ``EASYSCIENCE_LOG_LEVEL`` environment variable when set.
+        """
         self._effective_default = _resolve_log_level(
             os.environ.get(_LOG_LEVEL_ENV_VAR), default=log_level
         )
@@ -100,10 +96,9 @@ class Logger:
         level : int | str
             Logging level — e.g. ``logging.WARNING``, ``'ERROR'``.
         """
-        if isinstance(level, str):
-            level = _resolve_log_level(level)
-        self.level = level
-        self.logger.setLevel(level)
+        resolved_level = _resolve_log_level(level) if isinstance(level, str) else level
+        self.level = resolved_level
+        self.logger.setLevel(resolved_level)
 
     def getLogger(self, logger_name: str) -> logging.Logger:
         """
@@ -124,26 +119,41 @@ class Logger:
             when *logger_name* does not already start with *easyscience*
             or a dot.
         """
-        if not logger_name.startswith('easyscience') and not logger_name.startswith('.'):
+        if not logger_name.startswith(PACKAGE_LOGGER_NAME) and not logger_name.startswith('.'):
             logger_name = f'{PACKAGE_LOGGER_NAME}.{logger_name}'
         return logging.getLogger(logger_name)
 
     @contextlib.contextmanager
-    def at_level(self, level: int | str):
+    def at_level(self, level: int | str) -> Iterator[None]:
         """
         Context manager that temporarily sets the package-root logger
         to *level*, restoring the previous level on exit.
 
-        Example::
+        Parameters
+        ----------
+        level : int | str
+            Temporary level for the package-root logger — e.g.
+            ``logging.ERROR`` or ``'ERROR'``.
 
-            with global_object.log.at_level(logging.ERROR):
-                fitter.fit(x, y, weights)  # no core messages below ERROR
+        Yields
+        ------
+        None
+            Control is handed back to the ``with`` block with the
+            temporary level applied.
+
+        Example
+        -------
+        Setting the log-level only within the context:
+
+        ```python
+        with global_object.log.at_level(logging.ERROR):
+            fitter.fit(x, y, weights)  # no core messages below ERROR
+        ```
         """
         previous = self.level
-        if isinstance(level, str):
-            level = _resolve_log_level(level)
-        self.level = level
-        self.logger.setLevel(level)
+        resolved_level = _resolve_log_level(level) if isinstance(level, str) else level
+        self.level = resolved_level
+        self.logger.setLevel(resolved_level)
         try:
             yield
         finally:

--- a/src/easyscience/global_object/undo_redo.py
+++ b/src/easyscience/global_object/undo_redo.py
@@ -3,6 +3,7 @@
 
 import abc
 import functools
+import logging
 from collections import UserDict
 from collections import deque
 from typing import Any
@@ -233,7 +234,7 @@ class UndoStack:
                     self._command_running = True
                     command.undo()
                 except Exception as e:
-                    print(e)
+                    logging.getLogger('easyscience.global_object.undo_redo').warning(str(e))
                 finally:
                     self._command_running = False
 
@@ -251,7 +252,7 @@ class UndoStack:
                     self._command_running = True
                     command.redo()
                 except Exception as e:
-                    print(e)
+                    logging.getLogger('easyscience.global_object.undo_redo').warning(str(e))
                 finally:
                     self._command_running = False
 
@@ -446,7 +447,9 @@ def property_stack(arg: Union[str, Callable], begin_macro: bool = False) -> Call
                 return
 
             if global_object.debug:
-                print(f"I'm {obj} and have been set from {old_value} to {new_value}!")
+                logging.getLogger('easyscience.global_object.undo_redo').debug(
+                    "I'm %s and have been set from %s to %s!", obj, old_value, new_value
+                )
 
             global_object.stack.push(PropertyStack(obj, func, old_value, new_value, **kwargs))
 

--- a/src/easyscience/legacy/collection_base.py
+++ b/src/easyscience/legacy/collection_base.py
@@ -71,7 +71,8 @@ class CollectionBase(BasedBase, MutableSequence):
         """
         global_object.log.getLogger('legacy').warning(
             'CollectionBase is deprecated and will be removed in a future version. '
-            'Please migrate to ModelBase or EasyList.'
+            'Please migrate to ModelBase or EasyList.',
+            stacklevel=2,
         )
         BasedBase.__init__(self, name, unique_name=unique_name)
         kwargs = {key: kwargs[key] for key in kwargs.keys() if kwargs[key] is not None}

--- a/src/easyscience/legacy/collection_base.py
+++ b/src/easyscience/legacy/collection_base.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import warnings
+import logging
 from collections.abc import MutableSequence
 from numbers import Number
 from typing import TYPE_CHECKING
@@ -69,11 +69,9 @@ class CollectionBase(BasedBase, MutableSequence):
             If a provided item is not an EasyScience object or if a
             keyword collides with an internal attribute.
         """
-        warnings.warn(
+        logging.getLogger('easyscience.legacy').warning(
             'CollectionBase is deprecated and will be removed in a future version. '
-            'Please migrate to ModelBase or EasyList.',
-            DeprecationWarning,
-            stacklevel=2,
+            'Please migrate to ModelBase or EasyList.'
         )
         BasedBase.__init__(self, name, unique_name=unique_name)
         kwargs = {key: kwargs[key] for key in kwargs.keys() if kwargs[key] is not None}

--- a/src/easyscience/legacy/collection_base.py
+++ b/src/easyscience/legacy/collection_base.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import MutableSequence
 from numbers import Number
 from typing import TYPE_CHECKING
@@ -14,6 +13,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from easyscience import global_object
 from easyscience.base_classes.new_base import NewBase
 from easyscience.global_object.undo_redo import NotarizedDict
 
@@ -69,7 +69,7 @@ class CollectionBase(BasedBase, MutableSequence):
             If a provided item is not an EasyScience object or if a
             keyword collides with an internal attribute.
         """
-        logging.getLogger('easyscience.legacy').warning(
+        global_object.log.getLogger('legacy').warning(
             'CollectionBase is deprecated and will be removed in a future version. '
             'Please migrate to ModelBase or EasyList.'
         )

--- a/src/easyscience/legacy/obj_base.py
+++ b/src/easyscience/legacy/obj_base.py
@@ -61,7 +61,8 @@ class ObjBase(BasedBase):
         """
         global_object.log.getLogger('legacy').warning(
             'ObjBase is deprecated and will be removed in a future version. '
-            'Please migrate to ModelBase.'
+            'Please migrate to ModelBase.',
+            stacklevel=2,
         )
         super(ObjBase, self).__init__(name=name, unique_name=unique_name)
         # If Parameter or Descriptor is given as arguments...

--- a/src/easyscience/legacy/obj_base.py
+++ b/src/easyscience/legacy/obj_base.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import warnings
+import logging
 from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Optional
@@ -58,11 +58,9 @@ class ObjBase(BasedBase):
             If a keyword component name would overwrite an existing
             class attribute.
         """
-        warnings.warn(
+        logging.getLogger('easyscience.legacy').warning(
             'ObjBase is deprecated and will be removed in a future version. '
-            'Please migrate to ModelBase.',
-            DeprecationWarning,
-            stacklevel=2,
+            'Please migrate to ModelBase.'
         )
         super(ObjBase, self).__init__(name=name, unique_name=unique_name)
         # If Parameter or Descriptor is given as arguments...

--- a/src/easyscience/legacy/obj_base.py
+++ b/src/easyscience/legacy/obj_base.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Optional
+
+from easyscience import global_object
 
 from ..base_classes.based_base import BasedBase
 from ..utils.classTools import addLoggedProp
@@ -58,7 +59,7 @@ class ObjBase(BasedBase):
             If a keyword component name would overwrite an existing
             class attribute.
         """
-        logging.getLogger('easyscience.legacy').warning(
+        global_object.log.getLogger('legacy').warning(
             'ObjBase is deprecated and will be removed in a future version. '
             'Please migrate to ModelBase.'
         )

--- a/src/easyscience/legacy/xml.py
+++ b/src/easyscience/legacy/xml.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 import sys
 import xml.etree.ElementTree as ET
 from numbers import Number
@@ -13,6 +12,8 @@ from typing import List
 from typing import Optional
 
 import numpy as np
+
+from easyscience import global_object
 
 from ..io.dict import DataDictSerializer
 from ..io.dict import DictSerializer
@@ -192,5 +193,5 @@ class XMLSerializer(BaseEncoderDecoder):
         elif issubclass(T_, np.ndarray):
             element.text = str(value.tolist())
         else:
-            logging.getLogger('easyscience.legacy.xml').error('Cannot encode %s to XML', T_)
+            global_object.log.getLogger('legacy.xml').error('Cannot encode %s to XML', T_)
             raise NotImplementedError

--- a/src/easyscience/legacy/xml.py
+++ b/src/easyscience/legacy/xml.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import xml.etree.ElementTree as ET
 from numbers import Number
@@ -191,5 +192,5 @@ class XMLSerializer(BaseEncoderDecoder):
         elif issubclass(T_, np.ndarray):
             element.text = str(value.tolist())
         else:
-            print(f'Cannot encode {T_} to XML')
+            logging.getLogger('easyscience.legacy.xml').error('Cannot encode %s to XML', T_)
             raise NotImplementedError

--- a/src/easyscience/utils/decorators.py
+++ b/src/easyscience/utils/decorators.py
@@ -3,7 +3,7 @@
 
 import collections.abc
 import functools
-import warnings
+import logging
 from time import time
 from typing import Any
 from typing import Callable
@@ -99,11 +99,9 @@ def deprecated(func):
 
     @functools.wraps(func)
     def new_func(*args, **kwargs):
-        warnings.warn_explicit(
-            'Call to deprecated function {}.'.format(func.__name__),
-            category=DeprecationWarning,
-            filename=func.__code__.co_filename,
-            lineno=func.__code__.co_firstlineno + 1,
+        logging.getLogger('easyscience.deprecated').warning(
+            'Call to deprecated function %s.', func.__name__,
+            stacklevel=3,
         )
         return func(*args, **kwargs)
 

--- a/src/easyscience/utils/decorators.py
+++ b/src/easyscience/utils/decorators.py
@@ -3,7 +3,6 @@
 
 import collections.abc
 import functools
-import logging
 from time import time
 from typing import Any
 from typing import Callable
@@ -99,7 +98,7 @@ def deprecated(func):
 
     @functools.wraps(func)
     def new_func(*args, **kwargs):
-        logging.getLogger('easyscience.deprecated').warning(
+        global_object.log.getLogger('deprecated').warning(
             'Call to deprecated function %s.',
             func.__name__,
             stacklevel=3,

--- a/src/easyscience/utils/decorators.py
+++ b/src/easyscience/utils/decorators.py
@@ -100,7 +100,8 @@ def deprecated(func):
     @functools.wraps(func)
     def new_func(*args, **kwargs):
         logging.getLogger('easyscience.deprecated').warning(
-            'Call to deprecated function %s.', func.__name__,
+            'Call to deprecated function %s.',
+            func.__name__,
             stacklevel=3,
         )
         return func(*args, **kwargs)

--- a/src/easyscience/variable/parameter.py
+++ b/src/easyscience/variable/parameter.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import numbers
 import re
 import weakref
@@ -238,7 +237,7 @@ class Parameter(DescriptorNumber):
 
             self._notify_observers()
         else:
-            logging.getLogger('easyscience.variable').warning(
+            global_object.log.getLogger('variable').warning(
                 'This parameter is not dependent. It cannot be updated.'
             )
 

--- a/src/easyscience/variable/parameter.py
+++ b/src/easyscience/variable/parameter.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import copy
+import logging
 import numbers
 import re
-import warnings
 import weakref
 from typing import Any
 from typing import Dict
@@ -238,7 +238,9 @@ class Parameter(DescriptorNumber):
 
             self._notify_observers()
         else:
-            warnings.warn('This parameter is not dependent. It cannot be updated.')
+            logging.getLogger('easyscience.variable').warning(
+                'This parameter is not dependent. It cannot be updated.'
+            )
 
     def make_dependent_on(
         self,

--- a/src/easyscience/variable/parameter_dependency_resolver.py
+++ b/src/easyscience/variable/parameter_dependency_resolver.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 from typing import Dict
 from typing import List
+
+from easyscience import global_object
 
 from .parameter import Parameter
 
@@ -57,7 +58,7 @@ def resolve_all_parameter_dependencies(obj: Any) -> None:
                             attr_value = getattr(item, attr_name)
                             _collect_parameters(attr_value, parameters)
                         except (AttributeError, Exception):
-                            logging.getLogger('easyscience.variable.dependencies').debug(
+                            global_object.log.getLogger('variable.dependencies').debug(
                                 "Error accessing property '%s' of %s", attr_name, item
                             )
                             # Skip properties that can't be accessed
@@ -87,7 +88,7 @@ def resolve_all_parameter_dependencies(obj: Any) -> None:
 
     # Report results
     if resolved_count > 0:
-        logging.getLogger('easyscience.variable.dependencies').debug(
+        global_object.log.getLogger('variable.dependencies').debug(
             'Successfully resolved dependencies for %d parameter(s).', resolved_count
         )
 
@@ -144,7 +145,7 @@ def get_parameters_with_pending_dependencies(obj: Any) -> List[Parameter]:
                             attr_value = getattr(item, attr_name)
                             _collect_pending_parameters(attr_value)
                         except (AttributeError, Exception):
-                            logging.getLogger('easyscience.variable.dependencies').debug(
+                            global_object.log.getLogger('variable.dependencies').debug(
                                 "Error accessing property '%s' of %s", attr_name, item
                             )
                             # Skip properties that can't be accessed

--- a/src/easyscience/variable/parameter_dependency_resolver.py
+++ b/src/easyscience/variable/parameter_dependency_resolver.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from typing import Dict
 from typing import List
@@ -56,8 +57,9 @@ def resolve_all_parameter_dependencies(obj: Any) -> None:
                             attr_value = getattr(item, attr_name)
                             _collect_parameters(attr_value, parameters)
                         except (AttributeError, Exception):
-                            # log the exception
-                            print(f"Error accessing property '{attr_name}' of {item}")
+                            logging.getLogger('easyscience.variable.dependencies').debug(
+                                "Error accessing property '%s' of %s", attr_name, item
+                            )
                             # Skip properties that can't be accessed
                             continue
 
@@ -85,7 +87,9 @@ def resolve_all_parameter_dependencies(obj: Any) -> None:
 
     # Report results
     if resolved_count > 0:
-        print(f'Successfully resolved dependencies for {resolved_count} parameter(s).')
+        logging.getLogger('easyscience.variable.dependencies').debug(
+            'Successfully resolved dependencies for %d parameter(s).', resolved_count
+        )
 
     if error_count > 0:
         error_message = (
@@ -140,8 +144,9 @@ def get_parameters_with_pending_dependencies(obj: Any) -> List[Parameter]:
                             attr_value = getattr(item, attr_name)
                             _collect_pending_parameters(attr_value)
                         except (AttributeError, Exception):
-                            # log the exception
-                            print(f"Error accessing property '{attr_name}' of {item}")
+                            logging.getLogger('easyscience.variable.dependencies').debug(
+                                "Error accessing property '%s' of %s", attr_name, item
+                            )
                             # Skip properties that can't be accessed
                             continue
 

--- a/tests/unit/base_classes/test_deprecated_wrappers.py
+++ b/tests/unit/base_classes/test_deprecated_wrappers.py
@@ -3,12 +3,13 @@
 
 """Tests for the deprecated wrapper modules in easyscience.base_classes.
 
-These modules now only emit DeprecationWarnings and re-export from
-easyscience.legacy. We test that the warnings are raised and that
+These modules now only emit log warnings and re-export from
+easyscience.legacy. We test that the log messages are raised and that
 the classes are still usable.
 """
 
-import warnings
+import importlib
+import logging
 
 import pytest
 
@@ -28,24 +29,23 @@ def _clear_map():
 # ---------------------------------------------------------------------------
 
 
-def test_import_collection_base_warns():
-    """Importing easyscience.base_classes.collection_base emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        from easyscience.base_classes.collection_base import CollectionBase  # noqa: F811
+def test_import_collection_base_warns(caplog: "pytest.LogCaptureFixture"):
+    """Importing easyscience.base_classes.collection_base logs a WARNING."""
+    import easyscience.base_classes.collection_base
 
-        assert len(w) >= 1, 'Expected at least one DeprecationWarning'
-        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(deprecation_warnings) >= 1, 'Expected a DeprecationWarning'
-        msg = str(deprecation_warnings[0].message)
-        assert 'deprecated' in msg.lower()
-        assert 'legacy.collection_base' in msg
+    with caplog.at_level(logging.WARNING, logger='easyscience'):
+        importlib.reload(easyscience.base_classes.collection_base)
+
+    assert len(caplog.records) >= 1, 'Expected at least one log record'
+    messages = [r.message for r in caplog.records]
+    combined = ' '.join(messages)
+    assert 'deprecated' in combined.lower()
+    assert 'legacy.collection_base' in combined
 
 
-def test_collection_base_still_works_from_deprecated():
+def test_collection_base_still_works_from_deprecated(caplog: "pytest.LogCaptureFixture"):
     """The class imported from the deprecated wrapper still works."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
+    with caplog.at_level(logging.ERROR, logger='easyscience'):
         from easyscience.base_classes.collection_base import CollectionBase  # noqa: F811
 
     from easyscience import Parameter
@@ -61,24 +61,23 @@ def test_collection_base_still_works_from_deprecated():
 # ---------------------------------------------------------------------------
 
 
-def test_import_obj_base_warns():
-    """Importing easyscience.base_classes.obj_base emits DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        from easyscience.base_classes.obj_base import ObjBase  # noqa: F811
+def test_import_obj_base_warns(caplog: "pytest.LogCaptureFixture"):
+    """Importing easyscience.base_classes.obj_base logs a WARNING."""
+    import easyscience.base_classes.obj_base
 
-        assert len(w) >= 1, 'Expected at least one DeprecationWarning'
-        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(deprecation_warnings) >= 1, 'Expected a DeprecationWarning'
-        msg = str(deprecation_warnings[0].message)
-        assert 'deprecated' in msg.lower()
-        assert 'legacy.obj_base' in msg
+    with caplog.at_level(logging.WARNING, logger='easyscience'):
+        importlib.reload(easyscience.base_classes.obj_base)
+
+    assert len(caplog.records) >= 1, 'Expected at least one log record'
+    messages = [r.message for r in caplog.records]
+    combined = ' '.join(messages)
+    assert 'deprecated' in combined.lower()
+    assert 'legacy.obj_base' in combined
 
 
-def test_obj_base_still_works_from_deprecated():
+def test_obj_base_still_works_from_deprecated(caplog: "pytest.LogCaptureFixture"):
     """The class imported from the deprecated wrapper still works."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', DeprecationWarning)
+    with caplog.at_level(logging.ERROR, logger='easyscience'):
         from easyscience.base_classes.obj_base import ObjBase  # noqa: F811
 
     from easyscience import Parameter

--- a/tests/unit/base_classes/test_deprecated_wrappers.py
+++ b/tests/unit/base_classes/test_deprecated_wrappers.py
@@ -29,7 +29,7 @@ def _clear_map():
 # ---------------------------------------------------------------------------
 
 
-def test_import_collection_base_warns(caplog: "pytest.LogCaptureFixture"):
+def test_import_collection_base_warns(caplog: 'pytest.LogCaptureFixture'):
     """Importing easyscience.base_classes.collection_base logs a WARNING."""
     import easyscience.base_classes.collection_base
 
@@ -43,7 +43,7 @@ def test_import_collection_base_warns(caplog: "pytest.LogCaptureFixture"):
     assert 'legacy.collection_base' in combined
 
 
-def test_collection_base_still_works_from_deprecated(caplog: "pytest.LogCaptureFixture"):
+def test_collection_base_still_works_from_deprecated(caplog: 'pytest.LogCaptureFixture'):
     """The class imported from the deprecated wrapper still works."""
     with caplog.at_level(logging.ERROR, logger='easyscience'):
         from easyscience.base_classes.collection_base import CollectionBase  # noqa: F811
@@ -61,7 +61,7 @@ def test_collection_base_still_works_from_deprecated(caplog: "pytest.LogCaptureF
 # ---------------------------------------------------------------------------
 
 
-def test_import_obj_base_warns(caplog: "pytest.LogCaptureFixture"):
+def test_import_obj_base_warns(caplog: 'pytest.LogCaptureFixture'):
     """Importing easyscience.base_classes.obj_base logs a WARNING."""
     import easyscience.base_classes.obj_base
 
@@ -75,7 +75,7 @@ def test_import_obj_base_warns(caplog: "pytest.LogCaptureFixture"):
     assert 'legacy.obj_base' in combined
 
 
-def test_obj_base_still_works_from_deprecated(caplog: "pytest.LogCaptureFixture"):
+def test_obj_base_still_works_from_deprecated(caplog: 'pytest.LogCaptureFixture'):
     """The class imported from the deprecated wrapper still works."""
     with caplog.at_level(logging.ERROR, logger='easyscience'):
         from easyscience.base_classes.obj_base import ObjBase  # noqa: F811

--- a/tests/unit/base_classes/test_easy_list.py
+++ b/tests/unit/base_classes/test_easy_list.py
@@ -219,7 +219,7 @@ class TestEasyList:
         assert el[0].unique_name == 'a3'
         assert el[1].unique_name == 'a4'
 
-    def test_setitem_self_replacement_int(self, caplog: "pytest.LogCaptureFixture"):
+    def test_setitem_self_replacement_int(self, caplog: 'pytest.LogCaptureFixture'):
         """e[0] = e[0] should work without warning."""
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
@@ -230,7 +230,7 @@ class TestEasyList:
         assert el[0].unique_name == 'a1'
         assert len(el) == 2
 
-    def test_setitem_self_replacement_slice(self, caplog: "pytest.LogCaptureFixture"):
+    def test_setitem_self_replacement_slice(self, caplog: 'pytest.LogCaptureFixture'):
         """e[0:2] = e[0:2] should work without warning."""
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
@@ -304,7 +304,7 @@ class TestEasyList:
 
     # --- Uniqueness ---
 
-    def test_append_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
+    def test_append_duplicate_warns(self, caplog: 'pytest.LogCaptureFixture'):
         a1 = Alpha(unique_name='a1')
         el = EasyList(a1, protected_types=Alpha)
         with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
@@ -313,7 +313,7 @@ class TestEasyList:
             assert 'already in EasyList' in caplog.records[0].message
         assert len(el) == 1
 
-    def test_insert_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
+    def test_insert_duplicate_warns(self, caplog: 'pytest.LogCaptureFixture'):
         a1 = Alpha(unique_name='a1')
         el = EasyList(a1, protected_types=Alpha)
         with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
@@ -322,7 +322,7 @@ class TestEasyList:
             assert 'already in EasyList' in caplog.records[0].message
         assert len(el) == 1
 
-    def test_setitem_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
+    def test_setitem_duplicate_warns(self, caplog: 'pytest.LogCaptureFixture'):
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         el = EasyList(a1, a2, protected_types=Alpha)
@@ -333,7 +333,7 @@ class TestEasyList:
         # Original value should remain unchanged
         assert el[0].unique_name == 'a1'
 
-    def test_setitem_slice_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
+    def test_setitem_slice_duplicate_warns(self, caplog: 'pytest.LogCaptureFixture'):
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         a3 = Alpha(unique_name='a3')

--- a/tests/unit/base_classes/test_easy_list.py
+++ b/tests/unit/base_classes/test_easy_list.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 
 import pytest
 
@@ -219,27 +219,25 @@ class TestEasyList:
         assert el[0].unique_name == 'a3'
         assert el[1].unique_name == 'a4'
 
-    def test_setitem_self_replacement_int(self):
+    def test_setitem_self_replacement_int(self, caplog: "pytest.LogCaptureFixture"):
         """e[0] = e[0] should work without warning."""
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         el = EasyList(a1, a2, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el[0] = el[0]
-            assert len(w) == 0
+            assert len(caplog.records) == 0
         assert el[0].unique_name == 'a1'
         assert len(el) == 2
 
-    def test_setitem_self_replacement_slice(self):
+    def test_setitem_self_replacement_slice(self, caplog: "pytest.LogCaptureFixture"):
         """e[0:2] = e[0:2] should work without warning."""
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         el = EasyList(a1, a2, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el[0:2] = [el[0], el[1]]
-            assert len(w) == 0
+            assert len(caplog.records) == 0
         assert el[0].unique_name == 'a1'
         assert el[1].unique_name == 'a2'
 
@@ -306,49 +304,45 @@ class TestEasyList:
 
     # --- Uniqueness ---
 
-    def test_append_duplicate_warns(self):
+    def test_append_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
         a1 = Alpha(unique_name='a1')
         el = EasyList(a1, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el.append(a1)
-            assert len(w) == 1
-            assert 'already in EasyList' in str(w[0].message)
+            assert len(caplog.records) == 1
+            assert 'already in EasyList' in caplog.records[0].message
         assert len(el) == 1
 
-    def test_insert_duplicate_warns(self):
+    def test_insert_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
         a1 = Alpha(unique_name='a1')
         el = EasyList(a1, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el.insert(0, a1)
-            assert len(w) == 1
-            assert 'already in EasyList' in str(w[0].message)
+            assert len(caplog.records) == 1
+            assert 'already in EasyList' in caplog.records[0].message
         assert len(el) == 1
 
-    def test_setitem_duplicate_warns(self):
+    def test_setitem_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         el = EasyList(a1, a2, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el[0] = a2  # a2 already at index 1
-            assert len(w) == 1
-            assert 'already in EasyList' in str(w[0].message)
+            assert len(caplog.records) == 1
+            assert 'already in EasyList' in caplog.records[0].message
         # Original value should remain unchanged
         assert el[0].unique_name == 'a1'
 
-    def test_setitem_slice_duplicate_warns(self):
+    def test_setitem_slice_duplicate_warns(self, caplog: "pytest.LogCaptureFixture"):
         a1 = Alpha(unique_name='a1')
         a2 = Alpha(unique_name='a2')
         a3 = Alpha(unique_name='a3')
         a4 = Alpha(unique_name='a4')
         el = EasyList(a1, a2, a3, protected_types=Alpha)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.base_classes'):
             el[0:3] = [a1, a3, a4]  # a3 already at index 2
-            assert len(w) == 1
-            assert 'already in EasyList' in str(w[0].message)
+            assert len(caplog.records) == 1
+            assert 'already in EasyList' in caplog.records[0].message
         assert el[0].unique_name == 'a1'
         assert el[1].unique_name == 'a2'  # a3 should not replace a2 because it's a duplicate
         assert el[2].unique_name == 'a4'

--- a/tests/unit/fitting/calculators/test_interface_factory.py
+++ b/tests/unit/fitting/calculators/test_interface_factory.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -204,7 +205,9 @@ class TestInterfaceFactoryTemplate:
         # Then
         mock_fitter.generate_bindings.assert_called_once()
 
-    def test_switch_with_fitter_exception_handling(self, factory_single_interface, capsys):
+    def test_switch_with_fitter_exception_handling(
+        self, factory_single_interface, caplog: "pytest.LogCaptureFixture"
+    ):
         """Test switch handles exceptions in fitter binding updates gracefully"""
         # Given
         mock_fit_object = MagicMock()
@@ -213,12 +216,12 @@ class TestInterfaceFactoryTemplate:
         mock_fitter._fit_object = mock_fit_object
 
         # When
-        factory_single_interface.switch('MockInterface1', fitter=mock_fitter)
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.calculators'):
+            factory_single_interface.switch('MockInterface1', fitter=mock_fitter)
 
         # Then
-        captured = capsys.readouterr()
-        assert 'Unable to auto generate bindings' in captured.out
-        assert 'Test exception' in captured.out
+        assert 'Unable to auto generate bindings' in caplog.text
+        assert 'Test exception' in caplog.text
 
     def test_fit_func_property_returns_callable(self, factory_single_interface):
         """Test fit_func property returns a callable"""
@@ -363,7 +366,7 @@ class TestInterfaceFactoryTemplate:
         assert name == 'MockInterface1'
 
     def test_switch_with_fitter_generate_bindings_exception(
-        self, factory_single_interface, capsys
+        self, factory_single_interface, caplog: "pytest.LogCaptureFixture"
     ):
         """Test switch handles exceptions in fitter.generate_bindings gracefully"""
         # Given
@@ -374,12 +377,12 @@ class TestInterfaceFactoryTemplate:
             del mock_fitter._fit_object
 
         # When
-        factory_single_interface.switch('MockInterface1', fitter=mock_fitter)
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.calculators'):
+            factory_single_interface.switch('MockInterface1', fitter=mock_fitter)
 
         # Then
-        captured = capsys.readouterr()
-        assert 'Unable to auto generate bindings' in captured.out
-        assert 'Generate bindings test exception' in captured.out
+        assert 'Unable to auto generate bindings' in caplog.text
+        assert 'Generate bindings test exception' in caplog.text
 
     def test_generate_bindings_with_property_without_value_no_call_back(
         self, factory_single_interface

--- a/tests/unit/fitting/calculators/test_interface_factory.py
+++ b/tests/unit/fitting/calculators/test_interface_factory.py
@@ -206,7 +206,7 @@ class TestInterfaceFactoryTemplate:
         mock_fitter.generate_bindings.assert_called_once()
 
     def test_switch_with_fitter_exception_handling(
-        self, factory_single_interface, caplog: "pytest.LogCaptureFixture"
+        self, factory_single_interface, caplog: 'pytest.LogCaptureFixture'
     ):
         """Test switch handles exceptions in fitter binding updates gracefully"""
         # Given
@@ -366,7 +366,7 @@ class TestInterfaceFactoryTemplate:
         assert name == 'MockInterface1'
 
     def test_switch_with_fitter_generate_bindings_exception(
-        self, factory_single_interface, caplog: "pytest.LogCaptureFixture"
+        self, factory_single_interface, caplog: 'pytest.LogCaptureFixture'
     ):
         """Test switch handles exceptions in fitter.generate_bindings gracefully"""
         # Given

--- a/tests/unit/fitting/minimizers/test_minimizer_bumps.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_bumps.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
+import logging
 from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -194,7 +195,7 @@ class TestBumpsFit:
         assert minimizer._cached_pars['b'].value == 2.0
         assert minimizer._cached_pars['b'].error == 0.2
 
-    def test_gen_fit_results(self, minimizer: Bumps, monkeypatch):
+    def test_gen_fit_results(self, minimizer: Bumps, monkeypatch, caplog: "pytest.LogCaptureFixture"):
         # When
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
@@ -224,12 +225,13 @@ class TestBumpsFit:
         minimizer.evaluate = MagicMock(return_value='evaluate')
 
         # Then
-        with pytest.warns(UserWarning, match='maximum optimizer steps of 3'):
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.bumps'):
             domain_fit_results = minimizer._gen_fit_results(
                 mock_fit_result,
                 max_evaluations=3,
                 **{'kwargs_set_key': 'kwargs_set_val'},
             )
+        assert 'maximum optimizer steps of 3' in caplog.text
 
         # Expect
         assert domain_fit_results == mock_domain_fit_results
@@ -636,7 +638,7 @@ class TestBumpsFit:
 
         assert parameter.value == 1.0
 
-    def test_gen_fit_results_uses_nit_for_budget_check(self, minimizer: Bumps, monkeypatch):
+    def test_gen_fit_results_uses_nit_for_budget_check(self, minimizer: Bumps, monkeypatch, caplog: "pytest.LogCaptureFixture"):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(
@@ -662,8 +664,10 @@ class TestBumpsFit:
         minimizer._eval_counter = MagicMock(count=2)
         minimizer.evaluate = MagicMock(return_value='evaluate')
 
-        with pytest.warns(UserWarning, match='maximum optimizer steps of 3'):
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.bumps'):
             domain_fit_results = minimizer._gen_fit_results(mock_fit_result, max_evaluations=3)
+
+        assert 'maximum optimizer steps of 3' in caplog.text
 
         assert domain_fit_results.success == False
         assert domain_fit_results.n_evaluations == 2

--- a/tests/unit/fitting/minimizers/test_minimizer_bumps.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_bumps.py
@@ -195,7 +195,9 @@ class TestBumpsFit:
         assert minimizer._cached_pars['b'].value == 2.0
         assert minimizer._cached_pars['b'].error == 0.2
 
-    def test_gen_fit_results(self, minimizer: Bumps, monkeypatch, caplog: "pytest.LogCaptureFixture"):
+    def test_gen_fit_results(
+        self, minimizer: Bumps, monkeypatch, caplog: 'pytest.LogCaptureFixture'
+    ):
         # When
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
@@ -638,7 +640,9 @@ class TestBumpsFit:
 
         assert parameter.value == 1.0
 
-    def test_gen_fit_results_uses_nit_for_budget_check(self, minimizer: Bumps, monkeypatch, caplog: "pytest.LogCaptureFixture"):
+    def test_gen_fit_results_uses_nit_for_budget_check(
+        self, minimizer: Bumps, monkeypatch, caplog: 'pytest.LogCaptureFixture'
+    ):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(

--- a/tests/unit/fitting/minimizers/test_minimizer_dfo.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_dfo.py
@@ -386,7 +386,7 @@ class TestDFOFit:
         )
 
     def test_gen_fit_results_maxfun_warning_sets_success_false_and_warns(
-        self, minimizer: DFO, monkeypatch, caplog: "pytest.LogCaptureFixture"
+        self, minimizer: DFO, monkeypatch, caplog: 'pytest.LogCaptureFixture'
     ):
         """When DFO returns EXIT_MAXFUN_WARNING, _gen_fit_results must warn and set success=False."""
         mock_domain_fit_results = MagicMock()
@@ -422,8 +422,9 @@ class TestDFOFit:
 
         assert DFO._extract_iterations(fit_results) == 5
 
-    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch,
-                                                   caplog: "pytest.LogCaptureFixture"):
+    def test_gen_fit_results_success_does_not_warn(
+        self, minimizer: DFO, monkeypatch, caplog: 'pytest.LogCaptureFixture'
+    ):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(
@@ -467,7 +468,9 @@ class TestDFOFit:
             easyscience.fitting.minimizers.minimizer_dfo.dfols, 'solve', mock_solve
         )
 
-    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch, caplog: "pytest.LogCaptureFixture"):
+    def test_gen_fit_results_success_does_not_warn(
+        self, minimizer: DFO, monkeypatch, caplog: 'pytest.LogCaptureFixture'
+    ):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(

--- a/tests/unit/fitting/minimizers/test_minimizer_dfo.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_dfo.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -386,7 +386,7 @@ class TestDFOFit:
         )
 
     def test_gen_fit_results_maxfun_warning_sets_success_false_and_warns(
-        self, minimizer: DFO, monkeypatch
+        self, minimizer: DFO, monkeypatch, caplog: "pytest.LogCaptureFixture"
     ):
         """When DFO returns EXIT_MAXFUN_WARNING, _gen_fit_results must warn and set success=False."""
         mock_domain_fit_results = MagicMock()
@@ -413,20 +413,17 @@ class TestDFOFit:
         minimizer._p_0 = 'p_0'
         minimizer.evaluate = MagicMock(return_value='evaluate')
 
-        with pytest.warns(UserWarning, match='Objective has been called MAXFUN times'):
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.dfo'):
             domain_fit_results = minimizer._gen_fit_results(mock_fit_result, np.array([1.0]))
 
-        assert domain_fit_results.success == False
-        assert domain_fit_results.n_evaluations == 50
-        assert domain_fit_results.message == 'Objective has been called MAXFUN times'
-
-    def test_extract_iterations_from_diagnostic_dict(self) -> None:
+        assert 'Objective has been called MAXFUN times' in caplog.text
         fit_results = MagicMock()
         fit_results.diagnostic_info = {'iters_total': [1, 2, 5]}
 
         assert DFO._extract_iterations(fit_results) == 5
 
-    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch):
+    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch,
+                                                   caplog: "pytest.LogCaptureFixture"):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(
@@ -451,9 +448,10 @@ class TestDFOFit:
         minimizer._p_0 = 'p_0'
         minimizer.evaluate = MagicMock(return_value='evaluate')
 
-        with pytest.warns(UserWarning, match='Objective has been called MAXFUN times'):
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.dfo'):
             domain_fit_results = minimizer._gen_fit_results(mock_fit_result, np.array([1.0]))
 
+        assert 'Objective has been called MAXFUN times' in caplog.text
         assert domain_fit_results.success == False
         assert domain_fit_results.n_evaluations == 50
         assert domain_fit_results.message == 'Objective has been called MAXFUN times'
@@ -469,7 +467,7 @@ class TestDFOFit:
             easyscience.fitting.minimizers.minimizer_dfo.dfols, 'solve', mock_solve
         )
 
-    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch):
+    def test_gen_fit_results_success_does_not_warn(self, minimizer: DFO, monkeypatch, caplog: "pytest.LogCaptureFixture"):
         mock_domain_fit_results = MagicMock()
         mock_FitResults = MagicMock(return_value=mock_domain_fit_results)
         monkeypatch.setattr(
@@ -494,11 +492,10 @@ class TestDFOFit:
         minimizer._p_0 = 'p_0'
         minimizer.evaluate = MagicMock(return_value='evaluate')
 
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.dfo'):
             domain_fit_results = minimizer._gen_fit_results(mock_fit_result, np.array([1.0]))
 
-        assert len(record) == 0
+        assert len(caplog.records) == 0
         assert domain_fit_results.success == True
 
     def test_dfo_fit_allows_maxfun_warning(self, minimizer: DFO, monkeypatch) -> None:

--- a/tests/unit/fitting/minimizers/test_minimizer_lmfit.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_lmfit.py
@@ -341,7 +341,7 @@ class TestLMFit:
             minimizer.fit(x=1.0, y=2.0, weights=1)
 
     def test_gen_fit_results_populates_evaluation_metadata(
-        self, minimizer: LMFit, caplog: "pytest.LogCaptureFixture"
+        self, minimizer: LMFit, caplog: 'pytest.LogCaptureFixture'
     ) -> None:
         fit_results = MagicMock()
         fit_results.success = False
@@ -366,7 +366,7 @@ class TestLMFit:
         assert result.engine_result == fit_results
 
     def test_gen_fit_results_success_does_not_warn(
-        self, minimizer: LMFit, caplog: "pytest.LogCaptureFixture"
+        self, minimizer: LMFit, caplog: 'pytest.LogCaptureFixture'
     ) -> None:
         fit_results = MagicMock()
         fit_results.success = True

--- a/tests/unit/fitting/minimizers/test_minimizer_lmfit.py
+++ b/tests/unit/fitting/minimizers/test_minimizer_lmfit.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
+import logging
 from unittest.mock import ANY
 from unittest.mock import MagicMock
 
@@ -340,7 +340,9 @@ class TestLMFit:
         with pytest.raises(FitError):
             minimizer.fit(x=1.0, y=2.0, weights=1)
 
-    def test_gen_fit_results_populates_evaluation_metadata(self, minimizer: LMFit) -> None:
+    def test_gen_fit_results_populates_evaluation_metadata(
+        self, minimizer: LMFit, caplog: "pytest.LogCaptureFixture"
+    ) -> None:
         fit_results = MagicMock()
         fit_results.success = False
         fit_results.data = 'data'
@@ -352,8 +354,10 @@ class TestLMFit:
         fit_results.nfev = 9
         fit_results.message = 'max evaluations reached'
 
-        with pytest.warns(UserWarning, match='max evaluations reached'):
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.lmfit'):
             result = minimizer._gen_fit_results(fit_results, iterations=4)
+
+        assert 'max evaluations reached' in caplog.text
 
         assert result.success is False
         assert result.n_evaluations == 9
@@ -361,7 +365,9 @@ class TestLMFit:
         assert result.message == 'max evaluations reached'
         assert result.engine_result == fit_results
 
-    def test_gen_fit_results_success_does_not_warn(self, minimizer: LMFit) -> None:
+    def test_gen_fit_results_success_does_not_warn(
+        self, minimizer: LMFit, caplog: "pytest.LogCaptureFixture"
+    ) -> None:
         fit_results = MagicMock()
         fit_results.success = True
         fit_results.data = 'data'
@@ -373,11 +379,10 @@ class TestLMFit:
         fit_results.nfev = 3
         fit_results.message = 'success'
 
-        with warnings.catch_warnings(record=True) as record:
-            warnings.simplefilter('always')
+        with caplog.at_level(logging.WARNING, logger='easyscience.fitting.lmfit'):
             result = minimizer._gen_fit_results(fit_results)
 
-        assert len(record) == 0
+        assert len(caplog.records) == 0
         assert result.success is True
 
     def test_convert_to_pars_obj(self, minimizer: LMFit, monkeypatch) -> None:

--- a/tests/unit/global_object/test_logger.py
+++ b/tests/unit/global_object/test_logger.py
@@ -76,6 +76,20 @@ class TestParseLogLevel:
         assert 'VERBOSE' in str(exc.value)
         assert 'WARNING' in str(exc.value)
 
+    @pytest.mark.parametrize('value', [True, False])
+    def test_bool_raises_type_error(self, value):
+        # bool is a subclass of int but must not be treated as a level number
+        with pytest.raises(TypeError) as exc:
+            _parse_log_level(value)
+        assert 'bool' in str(exc.value)
+
+    @pytest.mark.parametrize('value', [10.0, None, ['INFO'], (logging.INFO,)])
+    def test_non_int_non_str_raises_type_error(self, value):
+        # When Then — anything that is neither int nor str is rejected
+        with pytest.raises(TypeError) as exc:
+            _parse_log_level(value)
+        assert type(value).__name__ in str(exc.value)
+
 
 # ---------------------------------------------------------------------------
 # _env_log_level

--- a/tests/unit/global_object/test_logger.py
+++ b/tests/unit/global_object/test_logger.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: 2026 EasyScience contributors <https://github.com/easyscience>
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for easyscience.global_object.logger.
+
+Covers the module-level parsing helpers and the public surface of the
+``Logger`` class: the ``level`` property, ``getLogger``, the convenience
+delegation methods, the ``at_level`` context manager and the
+``suspend``/``resume`` shims.
+"""
+
+import logging
+
+import pytest
+
+from easyscience.global_object.logger import _LOG_LEVEL_ENV_VAR
+from easyscience.global_object.logger import PACKAGE_LOGGER_NAME
+from easyscience.global_object.logger import Logger
+from easyscience.global_object.logger import _env_log_level
+from easyscience.global_object.logger import _parse_log_level
+
+
+@pytest.fixture(autouse=True)
+def _restore_package_logger_level():
+    """Snapshot and restore the package-root logger level around each test.
+
+    ``Logger`` operates on the process-wide ``easyscience`` logger, so a
+    test that changes its level would otherwise leak into other tests.
+    """
+    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    previous = package_logger.level
+    yield
+    package_logger.setLevel(previous)
+
+
+# ---------------------------------------------------------------------------
+# _parse_log_level
+# ---------------------------------------------------------------------------
+
+
+class TestParseLogLevel:
+    def test_int_passthrough(self):
+        # When Then
+        assert _parse_log_level(logging.ERROR) == logging.ERROR
+        assert _parse_log_level(42) == 42
+
+    @pytest.mark.parametrize(
+        'name, expected',
+        [
+            ('DEBUG', logging.DEBUG),
+            ('INFO', logging.INFO),
+            ('WARNING', logging.WARNING),
+            ('ERROR', logging.ERROR),
+            ('CRITICAL', logging.CRITICAL),
+        ],
+    )
+    def test_level_names(self, name, expected):
+        # When Then
+        assert _parse_log_level(name) == expected
+
+    def test_name_is_case_insensitive_and_stripped(self):
+        # When Then
+        assert _parse_log_level('  error ') == logging.ERROR
+        assert _parse_log_level('Warning') == logging.WARNING
+
+    def test_numeric_string(self):
+        # When Then
+        assert _parse_log_level('40') == 40
+        assert _parse_log_level('  10 ') == 10
+
+    def test_unknown_name_raises_value_error(self):
+        # When Then
+        with pytest.raises(ValueError) as exc:
+            _parse_log_level('VERBOSE')
+        # Expect the message to name the offending value and list valid options
+        assert 'VERBOSE' in str(exc.value)
+        assert 'WARNING' in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# _env_log_level
+# ---------------------------------------------------------------------------
+
+
+class TestEnvLogLevel:
+    def test_none_returns_default(self):
+        # When Then
+        assert _env_log_level(None, default=logging.WARNING) == logging.WARNING
+
+    def test_valid_value_is_parsed(self):
+        # When Then
+        assert _env_log_level('ERROR', default=logging.WARNING) == logging.ERROR
+        assert _env_log_level('10', default=logging.WARNING) == 10
+
+    def test_bad_value_falls_back_to_default(self):
+        # When Then — a typo must not raise, it falls back to the default
+        assert _env_log_level('NOPE', default=logging.INFO) == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# Logger.__init__
+# ---------------------------------------------------------------------------
+
+
+class TestLoggerInit:
+    def test_default_level_is_warning(self, monkeypatch):
+        # Given no env var set
+        monkeypatch.delenv(_LOG_LEVEL_ENV_VAR, raising=False)
+
+        # When
+        log = Logger()
+
+        # Then
+        assert log.level == logging.WARNING
+        assert log.logger.name == PACKAGE_LOGGER_NAME
+
+    def test_custom_default_level(self, monkeypatch):
+        # Given
+        monkeypatch.delenv(_LOG_LEVEL_ENV_VAR, raising=False)
+
+        # When
+        log = Logger(log_level=logging.DEBUG)
+
+        # Then
+        assert log.level == logging.DEBUG
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        # Given the env var requests ERROR
+        monkeypatch.setenv(_LOG_LEVEL_ENV_VAR, 'ERROR')
+
+        # When the default would have been WARNING
+        log = Logger(log_level=logging.WARNING)
+
+        # Then the env var wins
+        assert log.level == logging.ERROR
+
+    def test_invalid_env_var_falls_back_to_default(self, monkeypatch):
+        # Given a typo'd env var
+        monkeypatch.setenv(_LOG_LEVEL_ENV_VAR, 'NONSENSE')
+
+        # When
+        log = Logger(log_level=logging.INFO)
+
+        # Then import does not crash and the default is used
+        assert log.level == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# Logger.level property
+# ---------------------------------------------------------------------------
+
+
+class TestLevelProperty:
+    def test_getter_reflects_underlying_logger(self):
+        # Given
+        log = Logger()
+        log.logger.setLevel(logging.CRITICAL)
+
+        # When Then
+        assert log.level == logging.CRITICAL
+
+    def test_setter_accepts_int(self):
+        # Given
+        log = Logger()
+
+        # When
+        log.level = logging.DEBUG
+
+        # Then
+        assert log.logger.level == logging.DEBUG
+
+    def test_setter_accepts_level_name(self):
+        # Given
+        log = Logger()
+
+        # When
+        log.level = 'ERROR'
+
+        # Then
+        assert log.logger.level == logging.ERROR
+
+    def test_setter_raises_on_unknown_name(self):
+        # Given
+        log = Logger()
+
+        # When Then — the public API must be strict
+        with pytest.raises(ValueError):
+            log.level = 'LOUD'
+
+
+# ---------------------------------------------------------------------------
+# Logger.getLogger
+# ---------------------------------------------------------------------------
+
+
+class TestGetLogger:
+    def test_prefixes_with_package_name(self):
+        # Given
+        log = Logger()
+
+        # When
+        child = log.getLogger('fitting')
+
+        # Then
+        assert child.name == f'{PACKAGE_LOGGER_NAME}.fitting'
+
+    def test_does_not_double_prefix(self):
+        # Given a name that already starts with the package name
+        log = Logger()
+
+        # When
+        child = log.getLogger(f'{PACKAGE_LOGGER_NAME}.fitting.bumps')
+
+        # Then
+        assert child.name == f'{PACKAGE_LOGGER_NAME}.fitting.bumps'
+
+    def test_child_is_left_at_notset_to_inherit(self):
+        # Given
+        log = Logger()
+
+        # When
+        child = log.getLogger('some_unique_subsystem')
+
+        # Then it inherits configuration from the package root
+        assert child.level == logging.NOTSET
+
+
+# ---------------------------------------------------------------------------
+# Convenience delegation methods
+# ---------------------------------------------------------------------------
+
+
+class TestConvenienceMethods:
+    @pytest.mark.parametrize(
+        'method, level',
+        [
+            ('debug', logging.DEBUG),
+            ('info', logging.INFO),
+            ('warning', logging.WARNING),
+            ('error', logging.ERROR),
+            ('critical', logging.CRITICAL),
+        ],
+    )
+    def test_methods_emit_at_expected_level(self, caplog, method, level):
+        # Given
+        log = Logger()
+        log.level = logging.DEBUG
+
+        # When
+        with caplog.at_level(logging.DEBUG, logger=PACKAGE_LOGGER_NAME):
+            getattr(log, method)('hello %s', 'world')
+
+        # Then
+        records = [r for r in caplog.records if r.name == PACKAGE_LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == level
+        assert records[0].getMessage() == 'hello world'
+
+    def test_exception_logs_at_error_with_traceback(self, caplog):
+        # Given
+        log = Logger()
+        log.level = logging.DEBUG
+
+        # When
+        with caplog.at_level(logging.DEBUG, logger=PACKAGE_LOGGER_NAME):
+            try:
+                raise RuntimeError('boom')
+            except RuntimeError:
+                log.exception('caught it')
+
+        # Then
+        records = [r for r in caplog.records if r.name == PACKAGE_LOGGER_NAME]
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        assert records[0].exc_info is not None
+
+
+# ---------------------------------------------------------------------------
+# Logger.at_level context manager
+# ---------------------------------------------------------------------------
+
+
+class TestAtLevel:
+    def test_temporarily_sets_and_restores_level(self):
+        # Given
+        log = Logger()
+        log.level = logging.WARNING
+
+        # When
+        with log.at_level(logging.ERROR):
+            # Then inside the context the temporary level applies
+            assert log.level == logging.ERROR
+
+        # Then the previous level is restored on exit
+        assert log.level == logging.WARNING
+
+    def test_accepts_level_name(self):
+        # Given
+        log = Logger()
+        log.level = logging.INFO
+
+        # When
+        with log.at_level('CRITICAL'):
+            assert log.level == logging.CRITICAL
+
+        # Then
+        assert log.level == logging.INFO
+
+    def test_restores_level_on_exception(self):
+        # Given
+        log = Logger()
+        log.level = logging.WARNING
+
+        # When an exception escapes the context
+        with pytest.raises(RuntimeError):
+            with log.at_level(logging.ERROR):
+                raise RuntimeError('boom')
+
+        # Then the previous level is still restored
+        assert log.level == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
+# suspend / resume shims
+# ---------------------------------------------------------------------------
+
+
+class TestSuspendResume:
+    def test_suspend_silences_then_resume_restores(self):
+        # Given
+        log = Logger()
+        log.level = logging.INFO
+
+        # When
+        log.suspend()
+
+        # Then nothing below CRITICAL gets through
+        assert log.level > logging.CRITICAL
+
+        # When
+        log.resume()
+
+        # Then the pre-suspend level is restored
+        assert log.level == logging.INFO
+
+    def test_resume_uses_level_captured_at_suspend(self):
+        # Given a level set before suspending
+        log = Logger()
+        log.level = logging.ERROR
+        log.suspend()
+
+        # When
+        log.resume()
+
+        # Then
+        assert log.level == logging.ERROR

--- a/tests/unit/legacy/test_collection_base.py
+++ b/tests/unit/legacy/test_collection_base.py
@@ -7,7 +7,7 @@ These tests cover methods not exercised by the existing
 tests/unit/base_classes/test_collection_base.py suite.
 """
 
-import warnings
+import logging
 
 import pytest
 
@@ -40,14 +40,14 @@ def setup_pars():
 # Deprecation warning on instantiation
 # ---------------------------------------------------------------------------
 
-def test_instantiation_emits_deprecation_warning():
-    """Instantiating CollectionBase should emit a DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+def test_instantiation_emits_deprecation_warning(caplog: "pytest.LogCaptureFixture"):
+    """Instantiating CollectionBase should log a deprecation warning."""
+    with caplog.at_level(logging.WARNING, logger='easyscience.legacy'):
         CollectionBase('test')
-        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(deprecation_warnings) >= 1
-        assert 'deprecated' in str(deprecation_warnings[0].message).lower()
+        assert len(caplog.records) >= 1
+        messages = [r.message for r in caplog.records]
+        combined = ' '.join(messages)
+        assert 'deprecated' in combined.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/legacy/test_obj_base.py
+++ b/tests/unit/legacy/test_obj_base.py
@@ -7,7 +7,7 @@ These tests cover methods not exercised by the existing
 tests/unit/base_classes/test_obj_base.py suite.
 """
 
-import warnings
+import logging
 from typing import ClassVar
 
 import pytest
@@ -28,14 +28,14 @@ def _clear_map():
 # Deprecation warning on instantiation
 # ---------------------------------------------------------------------------
 
-def test_instantiation_emits_deprecation_warning():
-    """Instantiating ObjBase should emit a DeprecationWarning."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+def test_instantiation_emits_deprecation_warning(caplog: "pytest.LogCaptureFixture"):
+    """Instantiating ObjBase should log a deprecation warning."""
+    with caplog.at_level(logging.WARNING, logger='easyscience.legacy'):
         ObjBase('test')
-        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(deprecation_warnings) >= 1
-        assert 'deprecated' in str(deprecation_warnings[0].message).lower()
+        assert len(caplog.records) >= 1
+        messages = [r.message for r in caplog.records]
+        combined = ' '.join(messages)
+        assert 'deprecated' in combined.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Switched from direct `warnings.warn` and `print` statements to Python's standard `logging` module throughout the codebase. 


* Replaced all uses of `warnings.warn` and `print` for runtime and deprecation warnings with appropriate calls to the `logging` module, using named loggers under the `easyscience` hierarchy for better control and filtering. 


* Added a new user guide page, `controlling-log-output.md`, detailing how to suppress, filter, or redirect EasyScience log messages. 
 
* No global reconfiguration, no default stream handlers, and all loggers inherit configuration, giving users and downstream libraries full control over log output.

